### PR TITLE
chore: enforce identifier definition order

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,7 +17,8 @@
   },
   "plugins": ["react"],
   "rules": {
-    "import/order": ["error", { "newlines-between": "always" }]
+    "import/order": ["error", { "newlines-between": "always" }],
+    "no-use-before-define": ["error"]
   },
   "settings": {
     "react": {

--- a/components/Actions.js
+++ b/components/Actions.js
@@ -10,6 +10,17 @@ const A11Y_LABELS = {
   type: 'Add new secret by typing the details',
 }
 
+const styles = StyleSheet.create({
+  actions: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+  },
+  button: {
+    borderRadius: 100,
+    backgroundColor: theme.colors.primary,
+  },
+})
+
 export default function Actions({
   onScanNewSecretScreen,
   onUploadNewSecretScreen,
@@ -47,14 +58,3 @@ export default function Actions({
     </View>
   )
 }
-
-const styles = StyleSheet.create({
-  actions: {
-    flexDirection: 'row',
-    justifyContent: 'center',
-  },
-  button: {
-    borderRadius: 100,
-    backgroundColor: theme.colors.primary,
-  },
-})

--- a/components/Auth.js
+++ b/components/Auth.js
@@ -10,10 +10,29 @@ import Spacer from './Spacer'
 import Logo from './Logo'
 
 const UI_STRINGS = {
-  heading: 'Optic',
+  headline: 'Optic',
   subheading: 'Grant your favorite automated tools an OTP when they need it!',
   button: 'Sign in with Google',
 }
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: theme.colors.primary,
+    flexGrow: 1,
+    alignItems: 'center',
+    justifyContent: 'space-around',
+  },
+  text: {
+    textAlign: 'center',
+    color: theme.colors.surface,
+    paddingHorizontal: theme.spacing(7),
+  },
+  button: {
+    textAlign: 'center',
+    alignItems: 'center',
+    padding: theme.spacing(),
+  },
+})
 
 export default function Auth({ handleLogin }) {
   useEffect(() => {
@@ -32,7 +51,7 @@ export default function Auth({ handleLogin }) {
     <View style={styles.container}>
       <View>
         <Headline style={styles.text} color={theme.colors.surface}>
-          {UI_STRINGS.heading}
+          {UI_STRINGS.headline}
         </Headline>
         <Spacer size={4} />
         <BodyText style={styles.text}>{UI_STRINGS.subheading}</BodyText>
@@ -56,26 +75,3 @@ export default function Auth({ handleLogin }) {
     </View>
   )
 }
-
-const styles = StyleSheet.create({
-  container: {
-    backgroundColor: theme.colors.primary,
-    flexGrow: 1,
-    alignItems: 'center',
-    justifyContent: 'space-around',
-  },
-  title: {
-    textAlign: 'center',
-    color: theme.colors.surface,
-  },
-  text: {
-    textAlign: 'center',
-    color: theme.colors.surface,
-    paddingHorizontal: theme.spacing(7),
-  },
-  button: {
-    textAlign: 'center',
-    alignItems: 'center',
-    padding: theme.spacing(),
-  },
-})

--- a/components/EmptyTokensText.js
+++ b/components/EmptyTokensText.js
@@ -12,6 +12,13 @@ const UI_STRINGS = {
     'Add one by scanning or uploading a QR code, or even enter the details manually.',
 }
 
+const styles = StyleSheet.create({
+  description: {
+    paddingVertical: theme.spacing(4),
+    paddingHorizontal: theme.spacing(3),
+  },
+})
+
 export default function EmptyTokensText() {
   return (
     <View style={styles.description}>
@@ -22,10 +29,3 @@ export default function EmptyTokensText() {
     </View>
   )
 }
-
-const styles = StyleSheet.create({
-  description: {
-    paddingVertical: theme.spacing(4),
-    paddingHorizontal: theme.spacing(3),
-  },
-})

--- a/components/Home.js
+++ b/components/Home.js
@@ -8,6 +8,13 @@ import routes from '../lib/routeDefinitions'
 import EmptyTokensText from './EmptyTokensText'
 import Actions from './Actions'
 
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    width: '100%',
+  },
+})
+
 export default function Home() {
   const { navigate } = useNavigation()
   const { secrets } = useSecretsContext()
@@ -27,14 +34,3 @@ export default function Home() {
     </View>
   )
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flexGrow: 1,
-    width: '100%',
-  },
-  actions: {
-    flexDirection: 'row',
-    justifyContent: 'center',
-  },
-})

--- a/components/TypeNewSecret.js
+++ b/components/TypeNewSecret.js
@@ -8,6 +8,31 @@ import routes from '../lib/routeDefinitions'
 import { useAuthenticationContext } from '../context/authentication'
 import { useSecretsContext } from '../context/secrets'
 
+const UI_STRINGS = {
+  issuerTextInputLabel: 'Issuer',
+  secretTextInputLabel: 'Secret',
+  accountTextInput: 'Account',
+  addSecretButtonLabel: 'Add Secret',
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    width: '100%',
+  },
+  appBarTitle: {
+    color: theme.colors.surface,
+  },
+  form: {
+    padding: theme.spacing(0.5),
+  },
+  formTextInput: {
+    marginTop: theme.spacing(0.5),
+  },
+  formButton: {
+    marginTop: theme.spacing(1.5),
+  },
+})
+
 export default function TypeNewSecret() {
   const { user } = useAuthenticationContext()
   const { add } = useSecretsContext()
@@ -57,28 +82,3 @@ export default function TypeNewSecret() {
     </View>
   )
 }
-
-const UI_STRINGS = {
-  issuerTextInputLabel: 'Issuer',
-  secretTextInputLabel: 'Secret',
-  accountTextInput: 'Account',
-  addSecretButtonLabel: 'Add Secret',
-}
-
-const styles = StyleSheet.create({
-  screen: {
-    width: '100%',
-  },
-  appBarTitle: {
-    color: theme.colors.surface,
-  },
-  form: {
-    padding: theme.spacing(0.5),
-  },
-  formTextInput: {
-    marginTop: theme.spacing(0.5),
-  },
-  formButton: {
-    marginTop: theme.spacing(1.5),
-  },
-})

--- a/components/TypeNewSecret.js
+++ b/components/TypeNewSecret.js
@@ -16,7 +16,7 @@ export default function TypeNewSecret() {
   const [account, setAccount] = useState(user.displayName)
   const { navigate } = useNavigation()
 
-  const handleOnPress = async () => {
+  const handleAddSecretButtonPress = async () => {
     await add({ uid: user.uid, secret, account, issuer })
     navigate(routes.home.name)
   }
@@ -49,7 +49,7 @@ export default function TypeNewSecret() {
           style={styles.formButton}
           icon="plus"
           mode="contained"
-          onPress={handleOnPress}
+          onPress={handleAddSecretButtonPress}
         >
           {UI_STRINGS.addSecretButtonLabel}
         </Button>

--- a/components/typography.js
+++ b/components/typography.js
@@ -2,6 +2,20 @@ import React from 'react'
 import { Text } from 'react-native-paper'
 import { StyleSheet } from 'react-native'
 
+const styles = StyleSheet.create({
+  headline: {
+    fontFamily: 'Poppins_700Bold',
+    fontWeight: '700',
+    fontSize: 60,
+  },
+  bodyText: {
+    fontFamily: 'DidactGothic_400Regular',
+    fontWeight: '400',
+    fontSize: 16,
+    lineHeight: 24,
+  },
+})
+
 export function Headline({ children, color, style, ...props }) {
   return (
     <Text style={[styles.headline, color && { color }, style]} {...props}>
@@ -17,17 +31,3 @@ export function BodyText({ children, color, style, ...props }) {
     </Text>
   )
 }
-
-const styles = StyleSheet.create({
-  headline: {
-    fontFamily: 'Poppins_700Bold',
-    fontWeight: '700',
-    fontSize: 60,
-  },
-  bodyText: {
-    fontFamily: 'DidactGothic_400Regular',
-    fontWeight: '400',
-    fontSize: 16,
-    lineHeight: 24,
-  },
-})


### PR DESCRIPTION
A little housekeeping work here based on few comments and slack discussions around #13.

Effectively this PR do:

- Add the "no-use-before-define" eslint rule to our configuration to aid on enforcing the consensus arrived regarding the order in which ui strings and styles constants are defined in component files.
- Update event handler function name in `<TypeNewSecret />` function to a more meaningful one.