### PR TITLE
Feat | generate token for secret

### DIFF
--- a/components/Secret.js
+++ b/components/Secret.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import { StyleSheet, View, Text } from 'react-native'
+import { Button } from 'react-native-paper'
+
+import theme from '../lib/defaultTheme'
+
+const styles = StyleSheet.create({
+  container: {
+    margin: theme.spacing(2),
+    borderColor: 'black',
+  },
+})
+
+const UI_STRINGS = {
+  generateTokenButtonLabel: 'Generate Token',
+}
+
+export default function Secret({ data, onGenerateToken }) {
+  const handleGenerateTokenButtonPress = () => onGenerateToken(data)
+
+  return (
+    <View style={styles.container}>
+      <Text key={data._id}>{JSON.stringify(data)}</Text>
+      <Button mode="contained" onPress={handleGenerateTokenButtonPress}>
+        {UI_STRINGS.generateTokenButtonLabel}
+      </Button>
+    </View>
+  )
+}

--- a/components/screens/Home.js
+++ b/components/screens/Home.js
@@ -1,11 +1,14 @@
 import React from 'react'
-import { StyleSheet, View, Text } from 'react-native'
+import { StyleSheet, ScrollView } from 'react-native'
 import { useNavigation } from '@react-navigation/native'
 
 import { useSecrets } from '../../context/secrets'
+import { useAuthentication } from '../../context/authentication'
+import SecretsService from '../../lib/secretsService'
 import routes from '../../lib/routeDefinitions'
 import EmptyTokensText from '../EmptyTokensText'
 import Actions from '../Actions'
+import Secret from '../Secret'
 
 const styles = StyleSheet.create({
   container: {
@@ -16,24 +19,39 @@ const styles = StyleSheet.create({
 })
 
 export default function Home() {
+  const { user } = useAuthentication()
   const { navigate } = useNavigation()
-  const { secrets } = useSecrets()
+  const { secrets, update } = useSecrets()
+
+  const secretsService = new SecretsService(user)
+
+  const handleGenerateToken = async secret => {
+    try {
+      const token = await secretsService.generateToken(secret)
+      await update({ ...secret, token })
+    } catch (err) {
+      console.log(err)
+    }
+  }
 
   return (
-    <View style={styles.container}>
-      {secrets.length === 0 && <EmptyTokensText />}
-      <View>
-        {secrets.length > 0 &&
-          secrets.map(secret => (
-            <Text key={secret._id}>{JSON.stringify(secret)}</Text>
-          ))}
-      </View>
-
+    <ScrollView contentContainerStyle={styles.container}>
+      {secrets.length === 0 ? (
+        <EmptyTokensText />
+      ) : (
+        secrets.map(secret => (
+          <Secret
+            key={secret._id}
+            data={secret}
+            onGenerateToken={handleGenerateToken}
+          />
+        ))
+      )}
       <Actions
         onScanNewSecretScreen={() => navigate(routes.scan.name)}
         onUploadNewSecretScreen={() => navigate(routes.upload.name)}
         onTypeNewSecretScreen={() => navigate(routes.type.name)}
       />
-    </View>
+    </ScrollView>
   )
 }

--- a/context/authentication.js
+++ b/context/authentication.js
@@ -49,7 +49,15 @@ export function AuthenticationProvider({ children }) {
     }
   }, [response])
 
-  useEffect(() => firebase.auth().onAuthStateChanged(setUser), [])
+  useEffect(() => {
+    firebase.auth().onAuthStateChanged(async firebaseUser => {
+      setUser({
+        name: firebaseUser.name,
+        uid: firebaseUser.uid,
+        idToken: await firebaseUser.getIdToken(),
+      })
+    })
+  }, [])
 
   const handleLogout = useCallback(() => firebase.auth().signOut(), [])
 

--- a/context/secrets.js
+++ b/context/secrets.js
@@ -39,12 +39,21 @@ export function SecretsProvider({ children }) {
     [secretsManager]
   )
 
+  const update = useCallback(
+    async secret => {
+      await secretsManager.upsert(secret)
+      setSecrets(await secretsManager.find({ uid: secret.uid }))
+    },
+    [secretsManager]
+  )
+
   return (
     <SecretsContext.Provider
-      value={useMemo(() => ({ isInitialized, secrets, add }), [
+      value={useMemo(() => ({ isInitialized, secrets, add, update }), [
         isInitialized,
         secrets,
         add,
+        update,
       ])}
     >
       {children}

--- a/lib/secretsService.js
+++ b/lib/secretsService.js
@@ -1,0 +1,49 @@
+const apiUrl = 'https://optic-web.herokuapp.com/api'
+
+export default class SecretsService {
+  constructor(user) {
+    this.userIdToken = user.idToken
+  }
+
+  async generateToken(secret) {
+    const response = await fetch(`${apiUrl}/token/${secret._id}`, {
+      method: 'PUT',
+      headers: {
+        authorization: `Bearer ${this.userIdToken}`,
+      },
+    })
+
+    const { token } = await response.json()
+
+    return token
+  }
+
+  async revokeToken(secret) {
+    await fetch(`${apiUrl}/token/${secret._id}`, {
+      method: 'DELETE',
+      headers: {
+        authorization: `Bearer ${this.userIdToken}`,
+      },
+    })
+  }
+
+  async getServerPublicKey() {
+    const publicKeyResponse = await fetch(`${apiUrl}/vapidPublicKey`) // Why not secure??
+    return publicKeyResponse.text()
+  }
+
+  async registerSubscription(subscription) {
+    const response = await fetch(`${apiUrl}/register`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: `Bearer ${this.userIdToken}`,
+      },
+      body: JSON.stringify(subscription),
+    })
+
+    if (!response.ok) {
+      throw new Error('Cannot send subscription to server')
+    }
+  }
+}

--- a/tests/Main.test.js
+++ b/tests/Main.test.js
@@ -71,7 +71,7 @@ describe('Main', () => {
     expect(promptAsync).toHaveBeenCalledTimes(1)
   })
 
-  it('should render correct initial state for authenticated users', () => {
+  it('should render correct initial state for authenticated users', async () => {
     mockUseAuthRequest({
       type: 'success',
       params: {
@@ -79,13 +79,20 @@ describe('Main', () => {
       },
     })
 
+    const getIdTokenMock = jest.fn().mockResolvedValue('id-token')
+
     firebase.auth().onAuthStateChanged = jest.fn(callback =>
-      callback({ name: 'user' })
+      callback({
+        name: 'user',
+        getIdToken: getIdTokenMock,
+      })
     )
 
     const { getByText, getByA11yLabel } = renderWithTheme({
       ui: <Main />,
     })
+
+    await waitFor(() => expect(getIdTokenMock).toHaveBeenCalled())
 
     getByText(`No Secrets`)
     getByText('Add a new secret and it will appear here.')
@@ -120,13 +127,21 @@ describe('Main', () => {
       add: addSecretsMock,
     })
 
+    const getIdTokenMock = jest.fn().mockResolvedValue('id-token')
+
     firebase.auth().onAuthStateChanged = jest.fn(callback =>
-      callback({ name: 'user', uid: 'uid' })
+      callback({
+        name: 'user',
+        uid: 'uid',
+        getIdToken: getIdTokenMock,
+      })
     )
 
     const { queryByText, getByA11yLabel } = renderWithTheme({
       ui: <Main />,
     })
+
+    await waitFor(() => expect(getIdTokenMock).toHaveBeenCalled())
 
     expect(queryByText('Your Tokens')).not.toBeNull()
 

--- a/tests/secretsManager.test.js
+++ b/tests/secretsManager.test.js
@@ -1,14 +1,5 @@
-import {
-  isAvailableAsync,
-  getItemAsync,
-  setItemAsync,
-  deleteItemAsync,
-} from 'expo-secure-store'
-import {
-  getItem,
-  setItem,
-  removeItem,
-} from '@react-native-async-storage/async-storage'
+import { isAvailableAsync, getItemAsync, setItemAsync } from 'expo-secure-store'
+import { getItem, setItem } from '@react-native-async-storage/async-storage'
 
 import SecretsManager from '../lib/secretsManager'
 


### PR DESCRIPTION
Closes: #5 

This PR adds:

- A back-end service wrapper mostly ported over from optic-web.
- A bare bones `<Secret  />` component with a button to trigger the token generation.