### PR TITLE
chore: change url from heroku to GCP

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,1 +1,1 @@
-API_URL='https://optic-web.herokuapp.com/api'
+API_URL='https://optic-zf3votdk5a-ew.a.run.app/api'


### PR DESCRIPTION
Fixes https://github.com/nearform/optic/issues/31

I think the `API_URL` env key should be updated in the https://expo.dev/ site too


