### PR TITLE
Revert "chore(deps): bump react-native-safe-area-context from 3.3.2 to 4.2.4"

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "react-native-paper": "4.11.2",
     "react-native-reanimated": "~2.3.1",
     "react-native-root-toast": "^3.3.0",
-    "react-native-safe-area-context": "4.2.4",
+    "react-native-safe-area-context": "3.3.2",
     "react-native-screens": "~3.10.1",
     "react-native-svg": "12.3.0",
     "react-native-web": "0.17.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8654,10 +8654,10 @@ react-native-root-toast@^3.3.0:
     prop-types "^15.5.10"
     react-native-root-siblings "^4.0.0"
 
-react-native-safe-area-context@4.2.4:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.2.4.tgz#4df42819759c4d3c74252c8678c2772cfa2271a6"
-  integrity sha512-OOX+W2G4YYufvryonn6Kw6YnyT8ZThkxPHZBD04NLHaZmicUaaDVII/PZ3M5fD1o5N62+T+8K4bCS5Un2ggvkA==
+react-native-safe-area-context@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-3.3.2.tgz#9549a2ce580f2374edb05e49d661258d1b8bcaed"
+  integrity sha512-yOwiiPJ1rk+/nfK13eafbpW6sKW0jOnsRem2C1LPJjM3tfTof6hlvV5eWHATye3XOpu2cJ7N+HdkUvUDGwFD2Q==
 
 react-native-screens@^3.4.0, react-native-screens@~3.10.1:
   version "3.10.1"


### PR DESCRIPTION
Reverts nearform/optic-expo#437