### PR TITLE
feat: track pending notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react-native-screens": "~3.10.1",
     "react-native-svg": "12.3.0",
     "react-native-web": "0.17.1",
+    "react-timeago": "^6.2.1",
     "url-otpauth": "^2.0.0",
     "utility-types": "^3.10.0",
     "uuid": "8.3.2"
@@ -74,6 +75,7 @@
     "@types/react": "~17.0.43",
     "@types/react-native": "~0.64.12",
     "@types/react-test-renderer": "^17.0.1",
+    "@types/react-timeago": "^4.1.3",
     "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.16.0",
     "@typescript-eslint/parser": "^5.16.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { SecretsProvider } from './context/SecretsContext'
 import theme from './lib/theme'
 import Main from './Main'
 import { PrefsProvider } from './context/PrefsContext'
+import { PendingNotificationsProvider } from './context/PendingNotificationsContext'
 
 export default function App() {
   return (
@@ -16,10 +17,12 @@ export default function App() {
       <RootSiblingParent>
         <SecretsProvider>
           <PrefsProvider>
-            <PaperProvider theme={theme}>
-              <Main />
-              <StatusBar style="auto" />
-            </PaperProvider>
+            <PendingNotificationsProvider>
+              <PaperProvider theme={theme}>
+                <Main />
+                <StatusBar style="auto" />
+              </PaperProvider>
+            </PendingNotificationsProvider>
           </PrefsProvider>
         </SecretsProvider>
       </RootSiblingParent>

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -55,9 +55,7 @@ export type MainStackParamList = {
     uniqueId: string
     notificationId: string
   }
-  Notifications: {
-    //
-  }
+  Notifications: undefined
 }
 
 export default function Main() {

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -29,6 +29,7 @@ import { TokenScreen } from './screens/TokenScreen'
 import { OtpRequestScreen } from './screens/OtpRequestScreen'
 import { TokensListScreen } from './screens/TokensListScreen'
 import { CreateTokenScreen } from './screens/CreateTokenScreen'
+import { NotificationsScreen } from './screens/NotificationsScreen'
 
 const MainStack = createStackNavigator()
 
@@ -141,6 +142,11 @@ export default function Main() {
           name="Type"
           component={TypeScreen}
           options={{ title: 'New Secret', headerLeft: DefaultHeaderLeft }}
+        />
+        <MainStack.Screen
+          name="Notifications"
+          component={NotificationsScreen}
+          options={{ title: 'Notifications', headerLeft: DefaultHeaderLeft }}
         />
       </MainStack.Navigator>
     </NavigationContainer>

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -54,6 +54,9 @@ export type MainStackParamList = {
     uniqueId: string
     notificationId: string
   }
+  Notifications: {
+    //
+  }
 }
 
 export default function Main() {

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -52,6 +52,7 @@ export type MainStackParamList = {
     secretId: string
     token: string
     uniqueId: string
+    notificationId: string
   }
 }
 

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -53,7 +53,6 @@ export type MainStackParamList = {
     secretId: string
     token: string
     uniqueId: string
-    notificationId: string
   }
   Notifications: undefined
 }

--- a/src/components/HomeHeaderRight.tsx
+++ b/src/components/HomeHeaderRight.tsx
@@ -1,19 +1,35 @@
 import { useNavigation } from '@react-navigation/core'
 import { StackNavigationProp } from '@react-navigation/stack'
 import React from 'react'
+import { View } from 'react-native'
 import { IconButton } from 'react-native-paper'
 
 import theme from '../lib/theme'
+import { usePendingNotifications } from '../context/PendingNotificationsContext'
 import { MainStackParamList } from '../Main'
 
 export default function HomeHeaderRight() {
   const { navigate } = useNavigation<StackNavigationProp<MainStackParamList>>()
+  const { pendingNotifications } = usePendingNotifications()
+
+  const hasPendingNotifications = pendingNotifications.length > 0
 
   return (
-    <IconButton
-      icon="cog"
-      color={theme.colors.surface}
-      onPress={() => navigate('Settings')}
-    />
+    <View style={{ flexDirection: 'row', alignItems: 'flex-end' }}>
+      <IconButton
+        icon="bell"
+        color={
+          hasPendingNotifications
+            ? theme.colors.notification
+            : theme.colors.surface
+        }
+        onPress={() => navigate('Notifications')}
+      />
+      <IconButton
+        icon="cog"
+        color={theme.colors.surface}
+        onPress={() => navigate('Settings')}
+      />
+    </View>
   )
 }

--- a/src/components/HomeHeaderRight.tsx
+++ b/src/components/HomeHeaderRight.tsx
@@ -18,6 +18,7 @@ export default function HomeHeaderRight() {
     <View style={{ flexDirection: 'row', alignItems: 'flex-end' }}>
       <IconButton
         icon="bell"
+        // TODO: Add notifications counter instead of changing color
         color={
           hasPendingNotifications
             ? theme.colors.notification

--- a/src/components/NotificationCard.tsx
+++ b/src/components/NotificationCard.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import { Notification } from 'expo-notifications'
-import { StyleSheet, Text, View } from 'react-native'
-import { Avatar, Card } from 'react-native-paper'
+import { StyleSheet, View } from 'react-native'
+import { Avatar, Button, Card } from 'react-native-paper'
 
+import theme from '../lib/theme'
 import { useSecretSelector } from '../hooks/use-secret-selector'
 import { useTokenDataSelector } from '../hooks/use-token-data-selector'
-import theme from '../lib/theme'
 import { NotificationData } from '../types'
 
 import { Typography } from './Typography'
@@ -35,6 +35,11 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     marginBottom: theme.spacing(2),
   },
+  button: {
+    marginTop: theme.spacing(2),
+    marginHorizontal: theme.spacing(1),
+    flex: 1,
+  },
 })
 
 export const NoPendingNotifications = () => (
@@ -55,15 +60,14 @@ const TokenInfo: React.FC<TokenInfoProps> = ({ token, description }) => {
   return (
     <>
       <View style={styles.cardRow}>
-        <Text style={styles.label}>Token</Text>
+        <Typography variant="overline">Token</Typography>
         <View style={styles.tokenDescriptionRow}>
-          <Text>{token}</Text>
+          <Typography variant="code">{token}</Typography>
         </View>
       </View>
       <View style={styles.cardRow}>
-        <Text style={styles.label}>Token description</Text>
         <View style={styles.tokenDescriptionRow}>
-          <Text>{description}</Text>
+          <Typography variant="body1">{description}</Typography>
         </View>
       </View>
     </>
@@ -92,6 +96,22 @@ export const NotificationCard: React.FC<NotificationCardProps> = ({
         />
         <Card.Content>
           <TokenInfo token={token.token} description={token.description} />
+          <View style={{ flexDirection: 'row' }}>
+            <Button
+              style={styles.button}
+              mode="outlined"
+              onPress={() => undefined}
+            >
+              Reject
+            </Button>
+            <Button
+              style={styles.button}
+              mode="contained"
+              onPress={() => undefined}
+            >
+              Approve
+            </Button>
+          </View>
         </Card.Content>
       </Card>
     </View>

--- a/src/components/NotificationCard.tsx
+++ b/src/components/NotificationCard.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { StyleSheet, View } from 'react-native'
+
+import theme from '../lib/theme'
+
+import { Typography } from './Typography'
+
+const styles = StyleSheet.create({
+  noPendingNotifications: {
+    paddingTop: theme.spacing(8),
+    paddingHorizontal: theme.spacing(3),
+    alignItems: 'center',
+    flex: 1,
+  },
+})
+
+export const NoPendingNotifications = () => (
+  <View style={styles.noPendingNotifications}>
+    <Typography variant="h5" gutterBottom={4}>
+      No Pending Notifications
+    </Typography>
+    <Typography>New notifications will appear here.</Typography>
+  </View>
+)
+
+export const NotificationCard = () => <></>

--- a/src/components/NotificationCard.tsx
+++ b/src/components/NotificationCard.tsx
@@ -92,16 +92,15 @@ export const NotificationCard: React.FC<NotificationCardProps> = ({
   notification,
 }) => {
   const data = notification.request.content.data as NotificationData
-
   const secret = useSecretSelector(data.secretId)
   const token = useTokenDataSelector(data.secretId, data.token)
+  const { removeNotification } = usePendingNotifications()
 
   const { user } = useAuth()
   const { prefs } = usePrefs()
   const canUseLocalAuth = useCanUseLocalAuth()
-
   const api = useMemo(() => apiFactory({ idToken: user.idToken }), [user])
-  const { removeNotification } = usePendingNotifications()
+
   const [isLoading, setIsLoading] = useState(false)
 
   // This is sensible to clocks' drift and lack of synchronization, but if we
@@ -112,15 +111,15 @@ export const NotificationCard: React.FC<NotificationCardProps> = ({
     setIsLoading(true)
     await api.respond(secret.secret, data.uniqueId, false)
     await removeNotification(data.uniqueId)
-    setIsLoading(false)
-  }, [data.uniqueId, secret.secret, api, removeNotification])
+    // Don't do setIsLoading(false), as the component is unmounted anyway.
+  }, [data.uniqueId, secret.secret, api, removeNotification, setIsLoading])
 
   const approveRequest = useCallback(async () => {
     setIsLoading(true)
     await api.respond(secret.secret, data.uniqueId, true)
     await removeNotification(data.uniqueId)
-    setIsLoading(false)
-  }, [data.uniqueId, secret.secret, api, removeNotification])
+    // Don't do setIsLoading(false), as the component is unmounted anyway.
+  }, [data.uniqueId, secret.secret, api, removeNotification, setIsLoading])
 
   const handleApprove = useCallback(async () => {
     if (!canUseLocalAuth || !prefs.useBiometricAuth) {

--- a/src/components/NotificationCard.tsx
+++ b/src/components/NotificationCard.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
-import { StyleSheet, View } from 'react-native'
+import { Notification } from 'expo-notifications'
+import { StyleSheet, Text, View } from 'react-native'
+import { Avatar, Card } from 'react-native-paper'
 
+import { useSecretSelector } from '../hooks/use-secret-selector'
+import { useTokenDataSelector } from '../hooks/use-token-data-selector'
 import theme from '../lib/theme'
+import { NotificationData } from '../types'
 
 import { Typography } from './Typography'
 
@@ -11,6 +16,24 @@ const styles = StyleSheet.create({
     paddingHorizontal: theme.spacing(3),
     alignItems: 'center',
     flex: 1,
+  },
+  container: {
+    margin: theme.spacing(2),
+  },
+  cardRow: {
+    flex: 1,
+    marginTop: theme.spacing(2),
+    paddingHorizontal: theme.spacing(1),
+  },
+  label: {
+    color: theme.colors.textSecondary,
+    marginRight: theme.spacing(1),
+    fontSize: 10,
+  },
+  tokenDescriptionRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: theme.spacing(2),
   },
 })
 
@@ -23,4 +46,54 @@ export const NoPendingNotifications = () => (
   </View>
 )
 
-export const NotificationCard = () => <></>
+interface TokenInfoProps {
+  token: string
+  description: string
+}
+
+const TokenInfo: React.FC<TokenInfoProps> = ({ token, description }) => {
+  return (
+    <>
+      <View style={styles.cardRow}>
+        <Text style={styles.label}>Token</Text>
+        <View style={styles.tokenDescriptionRow}>
+          <Text>{token}</Text>
+        </View>
+      </View>
+      <View style={styles.cardRow}>
+        <Text style={styles.label}>Token description</Text>
+        <View style={styles.tokenDescriptionRow}>
+          <Text>{description}</Text>
+        </View>
+      </View>
+    </>
+  )
+}
+
+interface NotificationCardProps {
+  notification: Notification
+}
+
+export const NotificationCard: React.FC<NotificationCardProps> = ({
+  notification,
+}) => {
+  const data = notification.request.content.data as NotificationData
+
+  const secret = useSecretSelector(data.secretId)
+  const token = useTokenDataSelector(data.secretId, data.token)
+
+  return (
+    <View style={styles.container}>
+      <Card>
+        <Card.Title
+          title={<Typography variant="h5">{secret.issuer}</Typography>}
+          subtitle={secret.account}
+          left={props => <Avatar.Icon {...props} icon="key" />}
+        />
+        <Card.Content>
+          <TokenInfo token={token.token} description={token.description} />
+        </Card.Content>
+      </Card>
+    </View>
+  )
+}

--- a/src/components/NotificationCard.tsx
+++ b/src/components/NotificationCard.tsx
@@ -35,11 +35,6 @@ const styles = StyleSheet.create({
     marginTop: theme.spacing(2),
     paddingHorizontal: theme.spacing(1),
   },
-  label: {
-    color: theme.colors.textSecondary,
-    marginRight: theme.spacing(1),
-    fontSize: 10,
-  },
   tokenDescriptionRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
@@ -47,7 +42,16 @@ const styles = StyleSheet.create({
   },
   button: {
     marginTop: theme.spacing(2),
-    marginHorizontal: theme.spacing(1),
+    flex: 1,
+  },
+  leftButton: {
+    marginTop: theme.spacing(2),
+    marginRight: theme.spacing(1),
+    flex: 1,
+  },
+  rightButton: {
+    marginTop: theme.spacing(2),
+    marginLeft: theme.spacing(1),
     flex: 1,
   },
 })
@@ -167,14 +171,14 @@ export const NotificationCard: React.FC<NotificationCardProps> = ({
               ) : (
                 <>
                   <Button
-                    style={styles.button}
+                    style={styles.leftButton}
                     mode="outlined"
                     onPress={handleReject}
                   >
                     Reject
                   </Button>
                   <Button
-                    style={styles.button}
+                    style={styles.rightButton}
                     mode="contained"
                     onPress={handleApprove}
                   >

--- a/src/components/NotificationCard.tsx
+++ b/src/components/NotificationCard.tsx
@@ -1,14 +1,13 @@
 import React, { useCallback, useMemo, useState } from 'react'
 import TimeAgo from 'react-timeago'
 import * as LocalAuthentication from 'expo-local-authentication'
-import { Notification } from 'expo-notifications'
 import { StyleSheet, View } from 'react-native'
 import { Avatar, Button, Card, Text } from 'react-native-paper'
 
 import apiFactory from '../lib/api'
 import theme from '../lib/theme'
 import { LoadingSpinnerOverlay } from '../components/LoadingSpinnerOverlay'
-import { NotificationData } from '../types'
+import { OpticNotification } from '../types'
 import { useAuth } from '../context/AuthContext'
 import { useCanUseLocalAuth } from '../hooks/use-can-use-local-auth'
 import { usePendingNotifications } from '../context/PendingNotificationsContext'
@@ -89,13 +88,13 @@ const TokenInfo: React.FC<TokenInfoProps> = ({ token, description }) => {
 }
 
 interface NotificationCardProps {
-  notification: Notification
+  notification: OpticNotification
 }
 
 export const NotificationCard: React.FC<NotificationCardProps> = ({
   notification,
 }) => {
-  const data = notification.request.content.data as NotificationData
+  const data = notification.request.content.data
   const secret = useSecretSelector(data.secretId)
   const token = useTokenDataSelector(data.secretId, data.token)
   const { removeNotification } = usePendingNotifications()

--- a/src/context/PendingNotificationsContext.tsx
+++ b/src/context/PendingNotificationsContext.tsx
@@ -1,0 +1,54 @@
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
+
+import * as storage from '../lib/secure-storage'
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface PendingNotification {}
+
+const defaultPendingNotifications: PendingNotification[] = []
+
+const initialContext = {
+  pendingNotifications: defaultPendingNotifications,
+}
+
+const PendingNotificationsContext = createContext(initialContext)
+
+export const PendingNotificationsProvider = ({ children }) => {
+  const [pendingNotifications, setPendingNotifications] = useState(
+    defaultPendingNotifications
+  )
+
+  useEffect(() => {
+    async function fn() {
+      const s = await storage.getObject<PendingNotification[]>(
+        'pendingNotifications'
+      )
+      if (s) {
+        setPendingNotifications(s)
+      }
+    }
+
+    fn()
+  }, [])
+
+  const value = useMemo(
+    () => ({ pendingNotifications }),
+    [pendingNotifications]
+  )
+
+  return (
+    <PendingNotificationsContext.Provider value={value}>
+      {children}
+    </PendingNotificationsContext.Provider>
+  )
+}
+
+export function usePendingNotifications() {
+  return useContext(PendingNotificationsContext)
+}

--- a/src/context/PendingNotificationsContext.tsx
+++ b/src/context/PendingNotificationsContext.tsx
@@ -53,11 +53,11 @@ export const PendingNotificationsProvider = ({ children }) => {
           ...pendingNotifications,
           notification,
         ]
+        setPendingNotifications(updatedPendingNotifications)
         await storage.saveObject(
           'pendingNotifications',
           updatedPendingNotifications
         )
-        setPendingNotifications(updatedPendingNotifications)
       }
     },
     [pendingNotifications]

--- a/src/context/PendingNotificationsContext.tsx
+++ b/src/context/PendingNotificationsContext.tsx
@@ -39,7 +39,7 @@ export const PendingNotificationsProvider = ({ children }) => {
     }
 
     fn()
-  }, [])
+  }, [setPendingNotifications])
 
   const addNotification = useCallback(
     async (notification: Notification) => {
@@ -65,7 +65,7 @@ export const PendingNotificationsProvider = ({ children }) => {
         )
       }
     },
-    [pendingNotifications]
+    [pendingNotifications, setPendingNotifications]
   )
 
   const removeNotification = useCallback(
@@ -83,7 +83,7 @@ export const PendingNotificationsProvider = ({ children }) => {
         )
       }
     },
-    [pendingNotifications]
+    [pendingNotifications, setPendingNotifications]
   )
 
   const value = useMemo(

--- a/src/context/PendingNotificationsContext.tsx
+++ b/src/context/PendingNotificationsContext.tsx
@@ -6,16 +6,16 @@ import React, {
   useMemo,
   useState,
 } from 'react'
-import { Notification, dismissNotificationAsync } from 'expo-notifications'
+import { dismissNotificationAsync } from 'expo-notifications'
 
 import * as storage from '../lib/secure-storage'
-import { NotificationData } from '../types'
+import { type OpticNotification } from '../types'
 
-const defaultPendingNotifications: Notification[] = []
+const defaultPendingNotifications: OpticNotification[] = []
 
 const initialContext = {
   pendingNotifications: defaultPendingNotifications,
-  addNotification: async (_notification: Notification) => {
+  addNotification: async (_notification: OpticNotification) => {
     // set in context provider construction
   },
   removeNotification: async (_notificationId: string) => {
@@ -32,7 +32,9 @@ export const PendingNotificationsProvider = ({ children }) => {
 
   useEffect(() => {
     async function fn() {
-      const s = await storage.getObject<Notification[]>('pendingNotifications')
+      const s = await storage.getObject<OpticNotification[]>(
+        'pendingNotifications'
+      )
       if (s) {
         setPendingNotifications(s)
       }
@@ -42,15 +44,12 @@ export const PendingNotificationsProvider = ({ children }) => {
   }, [setPendingNotifications])
 
   const addNotification = useCallback(
-    async (notification: Notification) => {
-      const notificationId = (
-        notification.request.content.data as NotificationData
-      ).uniqueId
+    async (notification: OpticNotification) => {
+      const notificationId = notification.request.content.data.uniqueId
       const notAddedYet =
         pendingNotifications.findIndex(
           notification =>
-            (notification.request.content.data as NotificationData).uniqueId ===
-            notificationId
+            notification.request.content.data.uniqueId === notificationId
         ) === -1
 
       if (notAddedYet) {
@@ -72,8 +71,7 @@ export const PendingNotificationsProvider = ({ children }) => {
     async (notificationId: string) => {
       const updatedPendingNotifications = pendingNotifications.filter(
         notification =>
-          (notification.request.content.data as NotificationData).uniqueId !==
-          notificationId
+          notification.request.content.data.uniqueId !== notificationId
       )
       if (updatedPendingNotifications.length !== pendingNotifications.length) {
         setPendingNotifications(updatedPendingNotifications)
@@ -86,8 +84,7 @@ export const PendingNotificationsProvider = ({ children }) => {
         // identifier for their associated push notifications.
         const removedNotification = pendingNotifications.find(
           notification =>
-            (notification.request.content.data as NotificationData).uniqueId ===
-            notificationId
+            notification.request.content.data.uniqueId === notificationId
         )
         try {
           await dismissNotificationAsync(removedNotification.request.identifier)

--- a/src/context/PendingNotificationsContext.tsx
+++ b/src/context/PendingNotificationsContext.tsx
@@ -9,6 +9,7 @@ import React, {
 import { Notification } from 'expo-notifications'
 
 import * as storage from '../lib/secure-storage'
+import { NotificationData } from '../types'
 
 const defaultPendingNotifications: Notification[] = []
 
@@ -42,10 +43,14 @@ export const PendingNotificationsProvider = ({ children }) => {
 
   const addNotification = useCallback(
     async (notification: Notification) => {
-      const notificationId = notification.request.identifier
+      const notificationId = (
+        notification.request.content.data as NotificationData
+      ).uniqueId
       const notAddedYet =
         pendingNotifications.findIndex(
-          notification => notification.request.identifier === notificationId
+          notification =>
+            (notification.request.content.data as NotificationData).uniqueId ===
+            notificationId
         ) === -1
 
       if (notAddedYet) {
@@ -66,7 +71,9 @@ export const PendingNotificationsProvider = ({ children }) => {
   const removeNotification = useCallback(
     async (notificationId: string) => {
       const updatedPendingNotifications = pendingNotifications.filter(
-        notification => notification.request.identifier !== notificationId
+        notification =>
+          (notification.request.content.data as NotificationData).uniqueId !==
+          notificationId
       )
       if (updatedPendingNotifications.length !== pendingNotifications.length) {
         setPendingNotifications(updatedPendingNotifications)

--- a/src/context/PendingNotificationsContext.tsx
+++ b/src/context/PendingNotificationsContext.tsx
@@ -6,7 +6,7 @@ import React, {
   useMemo,
   useState,
 } from 'react'
-import { Notification } from 'expo-notifications'
+import { Notification, dismissNotificationAsync } from 'expo-notifications'
 
 import * as storage from '../lib/secure-storage'
 import { NotificationData } from '../types'
@@ -81,6 +81,19 @@ export const PendingNotificationsProvider = ({ children }) => {
           'pendingNotifications',
           updatedPendingNotifications
         )
+
+        // We use uniqueId to identify our OTP requests, but we use a different
+        // identifier for their associated push notifications.
+        const removedNotification = pendingNotifications.find(
+          notification =>
+            (notification.request.content.data as NotificationData).uniqueId ===
+            notificationId
+        )
+        try {
+          await dismissNotificationAsync(removedNotification.request.identifier)
+        } catch (e) {
+          console.warn(`Failed to dismiss push notification: ${e.message}`)
+        }
       }
     },
     [pendingNotifications, setPendingNotifications]

--- a/src/screens/HomeScreen.test.tsx
+++ b/src/screens/HomeScreen.test.tsx
@@ -15,6 +15,7 @@ jest.mock('@react-navigation/core', () => ({
 
 jest.mock('expo-notifications', () => ({
   setNotificationHandler: jest.fn(),
+  addNotificationReceivedListener: jest.fn(),
   addNotificationResponseReceivedListener: jest.fn(),
   removeNotificationSubscription: jest.fn(),
 }))

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -14,14 +14,8 @@ import apiFactory from '../lib/api'
 import { NoSecrets } from '../components/NoSecrets'
 import { Actions } from '../components/Actions'
 import { SecretCard } from '../components/SecretCard'
-import { Secret } from '../types'
+import { NotificationData, Secret } from '../types'
 import { MainStackParamList } from '../Main'
-
-type NotificationData = {
-  secretId: string
-  uniqueId: string
-  token: string
-}
 
 const styles = StyleSheet.create({
   container: {

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -14,7 +14,7 @@ import apiFactory from '../lib/api'
 import { NoSecrets } from '../components/NoSecrets'
 import { Actions } from '../components/Actions'
 import { SecretCard } from '../components/SecretCard'
-import { NotificationData, Secret } from '../types'
+import { NotificationData, OpticNotification, Secret } from '../types'
 import { MainStackParamList } from '../Main'
 
 const styles = StyleSheet.create({
@@ -81,7 +81,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
   }
 
   const onNotification = useCallback(
-    async (notification: Notifications.Notification) => {
+    async (notification: OpticNotification) => {
       addNotification(notification)
     },
     [addNotification]
@@ -100,14 +100,10 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
         return
       }
 
-      const notificationId = (
-        res.notification.request.content.data as NotificationData
-      ).uniqueId
       navigation.navigate('OtpRequest', {
         token,
         secretId,
         uniqueId,
-        notificationId,
       })
     },
     [navigation, secrets]

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -7,6 +7,7 @@ import { StackNavigationProp } from '@react-navigation/stack'
 import { useIsFocused } from '@react-navigation/core'
 import Toast from 'react-native-root-toast'
 
+import { usePendingNotifications } from '../context/PendingNotificationsContext'
 import { useSecrets } from '../context/SecretsContext'
 import { useAuth } from '../context/AuthContext'
 import apiFactory from '../lib/api'
@@ -48,6 +49,7 @@ type HomeScreenProps = {
 export const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
   const { user } = useAuth()
   const { secrets, remove } = useSecrets()
+  const { addNotification } = usePendingNotifications()
   const isFocused = useIsFocused()
   const notificationListener = useRef<Subscription>()
   const responseListener = useRef<Subscription>()
@@ -85,10 +87,10 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
   }
 
   const onNotification = useCallback(
-    async (_res: Notifications.Notification) => {
-      // Do nothing, for now
+    async (notification: Notifications.Notification) => {
+      addNotification(notification)
     },
-    []
+    [addNotification]
   )
 
   const onNotificationResponse = useCallback(
@@ -104,10 +106,12 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
         return
       }
 
+      const notificationId = res.notification.request.identifier
       navigation.navigate('OtpRequest', {
         token,
         secretId,
         uniqueId,
+        notificationId,
       })
     },
     [navigation, secrets]

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -100,7 +100,9 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
         return
       }
 
-      const notificationId = res.notification.request.identifier
+      const notificationId = (
+        res.notification.request.content.data as NotificationData
+      ).uniqueId
       navigation.navigate('OtpRequest', {
         token,
         secretId,

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -49,6 +49,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
   const { user } = useAuth()
   const { secrets, remove } = useSecrets()
   const isFocused = useIsFocused()
+  const notificationListener = useRef<Subscription>()
   const responseListener = useRef<Subscription>()
 
   const api = useMemo(() => apiFactory({ idToken: user.idToken }), [user])
@@ -84,6 +85,13 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
   }
 
   const onNotification = useCallback(
+    async (_res: Notifications.Notification) => {
+      // Do nothing, for now
+    },
+    []
+  )
+
+  const onNotificationResponse = useCallback(
     async (res: NotificationResponse) => {
       const data = res.notification.request.content.data as NotificationData
 
@@ -106,13 +114,19 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
   )
 
   useEffect(() => {
+    notificationListener.current =
+      Notifications.addNotificationReceivedListener(onNotification)
+
     responseListener.current =
-      Notifications.addNotificationResponseReceivedListener(onNotification)
+      Notifications.addNotificationResponseReceivedListener(
+        onNotificationResponse
+      )
 
     return () => {
       Notifications.removeNotificationSubscription(responseListener.current)
+      Notifications.removeNotificationSubscription(notificationListener.current)
     }
-  }, [onNotification])
+  }, [onNotification, onNotificationResponse])
 
   return (
     <View style={styles.container}>

--- a/src/screens/NotificationsScreen.tsx
+++ b/src/screens/NotificationsScreen.tsx
@@ -8,7 +8,6 @@ import {
 } from '../components/NotificationCard'
 import { usePendingNotifications } from '../context/PendingNotificationsContext'
 
-// TODO: Share styles object with HomeScreen.tsx?
 const styles = StyleSheet.create({
   container: {
     flexGrow: 1,
@@ -28,7 +27,12 @@ export const NotificationsScreen = () => {
       <ScrollView contentContainerStyle={styles.scrollView}>
         {pendingNotifications.length === 0
           ? NoPendingNotifications()
-          : pendingNotifications.map(() => NotificationCard())}
+          : pendingNotifications.map(notification => (
+              <NotificationCard
+                key={notification.request.identifier}
+                notification={notification}
+              />
+            ))}
       </ScrollView>
     </View>
   )

--- a/src/screens/NotificationsScreen.tsx
+++ b/src/screens/NotificationsScreen.tsx
@@ -1,5 +1,35 @@
 import React from 'react'
+import { StyleSheet, View } from 'react-native'
+import { ScrollView } from 'react-native-gesture-handler'
+
+import {
+  NoPendingNotifications,
+  NotificationCard,
+} from '../components/NotificationCard'
+import { usePendingNotifications } from '../context/PendingNotificationsContext'
+
+// TODO: Share styles object with HomeScreen.tsx?
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    justifyContent: 'flex-start',
+    width: '100%',
+  },
+  scrollView: {
+    flexGrow: 1,
+  },
+})
 
 export const NotificationsScreen = () => {
-  return <></>
+  const { pendingNotifications } = usePendingNotifications()
+
+  return (
+    <View style={styles.container}>
+      <ScrollView contentContainerStyle={styles.scrollView}>
+        {pendingNotifications.length === 0
+          ? NoPendingNotifications()
+          : pendingNotifications.map(() => NotificationCard())}
+      </ScrollView>
+    </View>
+  )
 }

--- a/src/screens/NotificationsScreen.tsx
+++ b/src/screens/NotificationsScreen.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export const NotificationsScreen = () => {
+  return <></>
+}

--- a/src/screens/NotificationsScreen.tsx
+++ b/src/screens/NotificationsScreen.tsx
@@ -7,6 +7,7 @@ import {
   NotificationCard,
 } from '../components/NotificationCard'
 import { usePendingNotifications } from '../context/PendingNotificationsContext'
+import { NotificationData } from '../types'
 
 const styles = StyleSheet.create({
   container: {
@@ -29,7 +30,10 @@ export const NotificationsScreen = () => {
           ? NoPendingNotifications()
           : pendingNotifications.map(notification => (
               <NotificationCard
-                key={notification.request.identifier}
+                key={
+                  (notification.request.content.data as NotificationData)
+                    .uniqueId
+                }
                 notification={notification}
               />
             ))}

--- a/src/screens/OtpRequestScreen.tsx
+++ b/src/screens/OtpRequestScreen.tsx
@@ -63,6 +63,7 @@ export const OtpRequestScreen = ({ route, navigation }: Props) => {
   const handleReject = useCallback(async () => {
     setIsLoading(true)
     await api.respond(secret.secret, uniqueId, false)
+    await removeNotification(notificationId)
     Toast.show('OTP request rejected')
     if (canGoBack()) {
       goBack()
@@ -70,7 +71,6 @@ export const OtpRequestScreen = ({ route, navigation }: Props) => {
       navigate('Home')
     }
     setIsLoading(false)
-    await removeNotification(notificationId)
   }, [
     api,
     canGoBack,
@@ -85,6 +85,7 @@ export const OtpRequestScreen = ({ route, navigation }: Props) => {
   const approveRequest = useCallback(async () => {
     setIsLoading(true)
     await api.respond(secret.secret, uniqueId, true)
+    await removeNotification(notificationId)
     Toast.show('OTP request approved')
     if (canGoBack()) {
       goBack()
@@ -92,7 +93,6 @@ export const OtpRequestScreen = ({ route, navigation }: Props) => {
       navigate('Home')
     }
     setIsLoading(false)
-    await removeNotification(notificationId)
   }, [
     api,
     canGoBack,

--- a/src/screens/OtpRequestScreen.tsx
+++ b/src/screens/OtpRequestScreen.tsx
@@ -7,6 +7,7 @@ import * as LocalAuthentication from 'expo-local-authentication'
 
 import theme from '../lib/theme'
 import { MainStackParamList } from '../Main'
+import { usePendingNotifications } from '../context/PendingNotificationsContext'
 import { useAuth } from '../context/AuthContext'
 import apiFactory from '../lib/api'
 import { Typography } from '../components/Typography'
@@ -51,11 +52,12 @@ export const OtpRequestScreen = ({ route, navigation }: Props) => {
   const canUseLocalAuth = useCanUseLocalAuth()
 
   const api = useMemo(() => apiFactory({ idToken: user.idToken }), [user])
-  const { token, secretId, uniqueId } = route.params
+  const { token, secretId, uniqueId, notificationId } = route.params
   const secret = useSecretSelector(secretId)
   const tokenData = useTokenDataSelector(secretId, token)
   const description = tokenData ? tokenData.description : ''
 
+  const { removeNotification } = usePendingNotifications()
   const [isLoading, setIsLoading] = useState(false)
 
   const handleReject = useCallback(async () => {
@@ -68,7 +70,17 @@ export const OtpRequestScreen = ({ route, navigation }: Props) => {
       navigate('Home')
     }
     setIsLoading(false)
-  }, [api, canGoBack, goBack, navigate, secret.secret, uniqueId])
+    await removeNotification(notificationId)
+  }, [
+    api,
+    canGoBack,
+    goBack,
+    navigate,
+    secret.secret,
+    uniqueId,
+    notificationId,
+    removeNotification,
+  ])
 
   const approveRequest = useCallback(async () => {
     setIsLoading(true)
@@ -80,7 +92,17 @@ export const OtpRequestScreen = ({ route, navigation }: Props) => {
       navigate('Home')
     }
     setIsLoading(false)
-  }, [api, canGoBack, goBack, navigate, secret.secret, uniqueId])
+    await removeNotification(notificationId)
+  }, [
+    api,
+    canGoBack,
+    goBack,
+    navigate,
+    secret.secret,
+    uniqueId,
+    notificationId,
+    removeNotification,
+  ])
 
   const handleApprove = useCallback(async () => {
     if (!canUseLocalAuth || !prefs.useBiometricAuth) return approveRequest()

--- a/src/screens/OtpRequestScreen.tsx
+++ b/src/screens/OtpRequestScreen.tsx
@@ -52,7 +52,7 @@ export const OtpRequestScreen = ({ route, navigation }: Props) => {
   const canUseLocalAuth = useCanUseLocalAuth()
 
   const api = useMemo(() => apiFactory({ idToken: user.idToken }), [user])
-  const { token, secretId, uniqueId, notificationId } = route.params
+  const { token, secretId, uniqueId } = route.params
   const secret = useSecretSelector(secretId)
   const tokenData = useTokenDataSelector(secretId, token)
   const description = tokenData ? tokenData.description : ''
@@ -63,7 +63,7 @@ export const OtpRequestScreen = ({ route, navigation }: Props) => {
   const handleReject = useCallback(async () => {
     setIsLoading(true)
     await api.respond(secret.secret, uniqueId, false)
-    await removeNotification(notificationId)
+    await removeNotification(uniqueId)
     Toast.show('OTP request rejected')
     if (canGoBack()) {
       goBack()
@@ -78,14 +78,13 @@ export const OtpRequestScreen = ({ route, navigation }: Props) => {
     navigate,
     secret.secret,
     uniqueId,
-    notificationId,
     removeNotification,
   ])
 
   const approveRequest = useCallback(async () => {
     setIsLoading(true)
     await api.respond(secret.secret, uniqueId, true)
-    await removeNotification(notificationId)
+    await removeNotification(uniqueId)
     Toast.show('OTP request approved')
     if (canGoBack()) {
       goBack()
@@ -100,7 +99,6 @@ export const OtpRequestScreen = ({ route, navigation }: Props) => {
     navigate,
     secret.secret,
     uniqueId,
-    notificationId,
     removeNotification,
   ])
 

--- a/src/screens/OtpRequestScreen.tsx
+++ b/src/screens/OtpRequestScreen.tsx
@@ -108,7 +108,7 @@ export const OtpRequestScreen = ({ route, navigation }: Props) => {
     if (!canUseLocalAuth || !prefs.useBiometricAuth) return approveRequest()
 
     const { success } = await LocalAuthentication.authenticateAsync()
-    if (success) approveRequest()
+    if (success) await approveRequest()
   }, [approveRequest, canUseLocalAuth, prefs])
 
   return (

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { type Notification } from 'expo-notifications'
+
 export type Token = {
   token: string
   description: string
@@ -28,4 +30,12 @@ export type NotificationData = {
   secretId: string
   uniqueId: string
   token: string
+}
+
+export type OpticNotification = Notification & {
+  request: {
+    content: {
+      data: NotificationData
+    }
+  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,3 +23,9 @@ export type User = {
   uid: string
   idToken: string
 }
+
+export type NotificationData = {
+  secretId: string
+  uniqueId: string
+  token: string
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2601,6 +2601,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-timeago@^4.1.3":
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/@types/react-timeago/-/react-timeago-4.1.3.tgz#957baaa9f8ea98457ee63b6a57b57a616066ba35"
+  integrity sha512-XaaMBzuXLw7lxPPDs/fenlohcf3NDqM5qP4oOL/Meu+Hb1QChW4Igw/SruS1llEqch18RQB3wDTIwvqq4nivvw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@>=16.9.0", "@types/react@~17.0.43":
   version "17.0.43"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.43.tgz#4adc142887dd4a2601ce730bc56c3436fdb07a55"
@@ -8719,6 +8726,11 @@ react-test-renderer@~17.0.1:
     react-is "^17.0.2"
     react-shallow-renderer "^16.13.1"
     scheduler "^0.20.2"
+
+react-timeago@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/react-timeago/-/react-timeago-6.2.1.tgz#f19716811156617ceb9c9f9a44315d85197c7fba"
+  integrity sha512-b9EObWO8wy4qwfOzj+g/RQZRrPvtMv1Pz12FCdAWKWCXbDGt0rZLyiyTGEr0Lh1O8w5xa48CtRpl3LI+CtGCyw==
 
 react@17.0.1:
   version "17.0.1"


### PR DESCRIPTION
## Changes
- Adds a new "notifications" section, where all pending notifications are listed to be handled (rejected, accepted, or dismissed in case they already expired).
- The pending notifications are persisted.
- The push notifications are automatically dismissed if the OTP requests are handled directly via the notifications section instead of doing that through the notifications provided by the smartphone's interface.

## About the scope
- For now, we don't keep track of all previous accepted & rejected OTP requests (once we handle them, we discard this information). I believe this should be discussed with more people, as it's a more advanced feature resembling a sort of audit log, and we might want to have support from the API side.

## Shortcomings
- Right now, the "notifications bell" does not have a nice numerical counter, it just turns to red instead when we have pending notifications. Before the reviews finish, I'll try to discover how to do that with our components. If don't arrive in time, we could defer it to another smaller PR.

Fixes #420 .