### PR TITLE
fix: update unit tests to remove usage of mocked from ts-jest/utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "jest-expo": "^44.0.0",
     "lint-staged": ">=13",
     "prettier": "^2.7.1",
-    "ts-jest": "^27.1.4",
+    "ts-jest": "^28.0.7",
     "typescript": "~4.7.4"
   },
   "lint-staged": {

--- a/src/Main.test.tsx
+++ b/src/Main.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { mocked } from 'ts-jest/utils'
 import { fireEvent } from '@testing-library/react-native'
 
 import { renderWithTheme } from '../test/utils'
@@ -10,27 +9,26 @@ import Main from './Main'
 import { User } from './types'
 
 jest.mock('./lib/api')
-
+jest.mock('./context/AuthContext')
 jest.mock('./hooks/use-push-token', () => () => 'dummy-expo-token')
-
-const useAuthMocked = mocked(useAuth)
-const apiFactoryMocked = mocked(apiFactory)
 
 describe('Main', () => {
   const handleLoginStub = jest.fn()
   const registerSubscriptionStub = jest.fn()
 
   beforeEach(() => {
-    useAuthMocked.mockReturnValue({
-      user: {} as User,
-      loading: false,
-      handleLogin: handleLoginStub,
-      handleLogout: jest.fn(),
-    })
+    (useAuth as jest.Mock)
+      .mockReturnValue({
+        user: {} as User,
+        loading: false,
+        handleLogin: handleLoginStub,
+        handleLogout: jest.fn(),
+      });
 
-    apiFactoryMocked.mockReturnValue({
-      registerSubscription: registerSubscriptionStub,
-    } as unknown as API)
+     (apiFactory as jest.Mock)
+      .mockReturnValue({
+        registerSubscription: registerSubscriptionStub,
+      });
   })
 
   afterEach(() => {
@@ -38,12 +36,12 @@ describe('Main', () => {
   })
 
   it('should render correct initial state for unauthenticated users', () => {
-    useAuthMocked.mockReturnValue({
+    (useAuth as jest.Mock).mockReturnValue({
       user: null,
       loading: false,
       handleLogin: handleLoginStub,
       handleLogout: jest.fn(),
-    })
+    });
 
     const { getByText, getByA11yLabel } = renderWithTheme(<Main />)
 

--- a/src/Main.test.tsx
+++ b/src/Main.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent } from '@testing-library/react-native'
 
 import { renderWithTheme } from '../test/utils'
 
-import apiFactory, { API } from './lib/api'
+import apiFactory from './lib/api'
 import { useAuth } from './context/AuthContext'
 import Main from './Main'
 import { User } from './types'
@@ -17,18 +17,15 @@ describe('Main', () => {
   const registerSubscriptionStub = jest.fn()
 
   beforeEach(() => {
-    (useAuth as jest.Mock)
-      .mockReturnValue({
-        user: {} as User,
-        loading: false,
-        handleLogin: handleLoginStub,
-        handleLogout: jest.fn(),
-      });
-
-     (apiFactory as jest.Mock)
-      .mockReturnValue({
-        registerSubscription: registerSubscriptionStub,
-      });
+    ;(useAuth as jest.Mock).mockReturnValue({
+      user: {} as User,
+      loading: false,
+      handleLogin: handleLoginStub,
+      handleLogout: jest.fn(),
+    })
+    ;(apiFactory as jest.Mock).mockReturnValue({
+      registerSubscription: registerSubscriptionStub,
+    })
   })
 
   afterEach(() => {
@@ -36,12 +33,12 @@ describe('Main', () => {
   })
 
   it('should render correct initial state for unauthenticated users', () => {
-    (useAuth as jest.Mock).mockReturnValue({
+    ;(useAuth as jest.Mock).mockReturnValue({
       user: null,
       loading: false,
       handleLogin: handleLoginStub,
       handleLogout: jest.fn(),
-    });
+    })
 
     const { getByText, getByA11yLabel } = renderWithTheme(<Main />)
 

--- a/src/lib/secretsManager.test.tsx
+++ b/src/lib/secretsManager.test.tsx
@@ -1,6 +1,5 @@
 import { v4 } from 'uuid'
-import { mocked } from 'ts-jest/utils'
-
+ 
 import { clearAll } from './secure-storage'
 import secretsManager from './secretsManager'
 
@@ -8,11 +7,10 @@ jest.mock('uuid', () => ({
   v4: jest.fn().mockReturnValue('uuid-1111'),
 }))
 
-const v4Mocked = mocked(v4)
-
+ 
 describe('secretsManager', () => {
   beforeEach(() => {
-    v4Mocked.mockReturnValue('uuid-1111')
+    (v4 as jest.Mock).mockReturnValue('uuid-1111')
   })
 
   afterEach(() => {
@@ -60,8 +58,9 @@ describe('secretsManager', () => {
   })
 
   it('persists and retrieves', async () => {
-    v4Mocked.mockReturnValueOnce('uuid-1111')
-    v4Mocked.mockReturnValueOnce('uuid-2222')
+    (v4 as jest.Mock)
+      .mockReturnValueOnce('uuid-1111')
+      .mockReturnValueOnce('uuid-2222')
 
     const s1 = await secretsManager.upsert(
       {

--- a/src/lib/secretsManager.test.tsx
+++ b/src/lib/secretsManager.test.tsx
@@ -1,5 +1,5 @@
 import { v4 } from 'uuid'
- 
+
 import { clearAll } from './secure-storage'
 import secretsManager from './secretsManager'
 
@@ -7,10 +7,9 @@ jest.mock('uuid', () => ({
   v4: jest.fn().mockReturnValue('uuid-1111'),
 }))
 
- 
 describe('secretsManager', () => {
   beforeEach(() => {
-    (v4 as jest.Mock).mockReturnValue('uuid-1111')
+    ;(v4 as jest.Mock).mockReturnValue('uuid-1111')
   })
 
   afterEach(() => {
@@ -58,7 +57,7 @@ describe('secretsManager', () => {
   })
 
   it('persists and retrieves', async () => {
-    (v4 as jest.Mock)
+    ;(v4 as jest.Mock)
       .mockReturnValueOnce('uuid-1111')
       .mockReturnValueOnce('uuid-2222')
 

--- a/src/lib/secure-storage/aes.ts
+++ b/src/lib/secure-storage/aes.ts
@@ -13,7 +13,6 @@ export const encryptWithRandomKey = async (
   data: string
 ): Promise<EncryptionResult> => {
   const encryptionKey = await generateRandomKey()
-
   const dataBytes = aesjs.utils.utf8.toBytes(data)
   const aesCtr = new aesjs.ModeOfOperation.ctr(
     encryptionKey,

--- a/src/lib/secure-storage/index.test.tsx
+++ b/src/lib/secure-storage/index.test.tsx
@@ -1,34 +1,28 @@
-import { mocked } from 'ts-jest/utils'
-
 import { setItem, getItem } from './storage'
-const { saveObject, getObject } = jest.requireActual('./index')
-
+import { saveObject, getObject } from './index';
+ 
 jest.mock('./storage', () => ({
   setItem: jest.fn(),
-  getItem: jest.fn(),
-}))
-
-const getItemMocked = mocked(getItem)
-const setItemMocked = mocked(setItem)
+  getItem: jest.fn()
+}));
 
 describe('storage', () => {
   afterEach(() => {
-    getItemMocked.mockClear()
-    setItemMocked.mockClear()
+    jest.resetAllMocks()
   })
 
   it('saveObject to reject when exception occurs in setItem', async () => {
-    setItemMocked.mockRejectedValueOnce('setItem error')
+    (setItem as jest.Mock).mockRejectedValueOnce('setItem error')
     await expect(saveObject('foo', 'bar')).rejects.toEqual('setItem error')
   })
 
   it('getObject to return null when exception occurs in getItem', async () => {
-    getItemMocked.mockRejectedValueOnce('getItem error')
+    (getItem as jest.Mock).mockRejectedValueOnce('getItem error')
     await expect(getObject('foo')).resolves.toBeNull()
   })
 
   it('getObject to return null when exception occurs in JSON.parse', async () => {
-    getItemMocked.mockResolvedValueOnce('bad json')
+    (getItem as jest.Mock).mockResolvedValueOnce('bad json')
     await expect(getObject('foo')).resolves.toBeNull()
   })
 })

--- a/src/lib/secure-storage/index.test.tsx
+++ b/src/lib/secure-storage/index.test.tsx
@@ -1,10 +1,11 @@
 import { setItem, getItem } from './storage'
-import { saveObject, getObject } from './index';
- 
+
+import { saveObject, getObject } from './index'
+
 jest.mock('./storage', () => ({
   setItem: jest.fn(),
-  getItem: jest.fn()
-}));
+  getItem: jest.fn(),
+}))
 
 describe('storage', () => {
   afterEach(() => {
@@ -12,17 +13,17 @@ describe('storage', () => {
   })
 
   it('saveObject to reject when exception occurs in setItem', async () => {
-    (setItem as jest.Mock).mockRejectedValueOnce('setItem error')
+    ;(setItem as jest.Mock).mockRejectedValueOnce('setItem error')
     await expect(saveObject('foo', 'bar')).rejects.toEqual('setItem error')
   })
 
   it('getObject to return null when exception occurs in getItem', async () => {
-    (getItem as jest.Mock).mockRejectedValueOnce('getItem error')
+    ;(getItem as jest.Mock).mockRejectedValueOnce('getItem error')
     await expect(getObject('foo')).resolves.toBeNull()
   })
 
   it('getObject to return null when exception occurs in JSON.parse', async () => {
-    (getItem as jest.Mock).mockResolvedValueOnce('bad json')
+    ;(getItem as jest.Mock).mockResolvedValueOnce('bad json')
     await expect(getObject('foo')).resolves.toBeNull()
   })
 })

--- a/src/lib/secure-storage/storage.test.tsx
+++ b/src/lib/secure-storage/storage.test.tsx
@@ -1,72 +1,56 @@
-import { writeAsStringAsync, readAsStringAsync } from 'expo-file-system'
+import { writeAsStringAsync, readAsStringAsync, getInfoAsync } from 'expo-file-system'
 import { getItemAsync, setItemAsync } from 'expo-secure-store'
-import { mocked } from 'ts-jest/utils'
-const { setItem, getItem } = jest.requireActual('./storage')
+ const { setItem, getItem } = jest.requireActual('./storage');
 
-jest.mock('expo-file-system', () => ({
-  writeAsStringAsync: jest.fn(),
-  getInfoAsync: jest.fn().mockReturnValue({ exists: true }),
-  readAsStringAsync: jest.fn(),
-}))
-
-jest.mock('expo-secure-store', () => ({
-  getItemAsync: jest.fn(),
-  setItemAsync: jest.fn(),
-}))
-
-global.crypto = {
-  getRandomValues: jest.fn().mockReturnValue(new Uint8Array(32)),
-}
-
-const writeAsStringAsyncMocked = mocked(writeAsStringAsync)
-const readAsStringAsyncMocked = mocked(readAsStringAsync)
-const getItemAsyncMocked = mocked(getItemAsync)
-const setItemAsyncMocked = mocked(setItemAsync)
-
+jest.mock('expo-file-system');
+jest.mock('expo-secure-store');
+ 
 describe('storage', () => {
-  afterEach(() => {
-    writeAsStringAsyncMocked.mockClear()
-    readAsStringAsyncMocked.mockClear()
-    getItemAsyncMocked.mockClear()
-    setItemAsyncMocked.mockClear()
-  })
+  beforeEach(() => {
+    jest.resetAllMocks();
+    global.crypto = {
+      getRandomValues: jest.fn().mockReturnValue(new Uint8Array(32)),
+    };
+    (getInfoAsync as jest.Mock).mockImplementation(() => ({ exists: true }));
+   })
 
   it('setItem to reject when exception occurs in readAsStringAsync', async () => {
-    readAsStringAsyncMocked.mockRejectedValueOnce('readAsStringAsync error')
+    (readAsStringAsync as jest.Mock).mockRejectedValueOnce('readAsStringAsync error');
     await expect(setItem('foo', 'bar')).rejects.toEqual(
       'readAsStringAsync error'
     )
   })
 
   it('setItem to reject when exception occurs in setItemAsync', async () => {
-    setItemAsyncMocked.mockRejectedValueOnce('setItemAsync error')
-    readAsStringAsyncMocked.mockReturnValueOnce(null)
+    (setItemAsync as jest.Mock).mockRejectedValueOnce('setItemAsync error');
+    (readAsStringAsync as jest.Mock).mockReturnValueOnce(null);
     await expect(setItem('foo', 'bar')).rejects.toEqual('setItemAsync error')
   })
 
   it('setItem to reject when exception occurs in writeAsStringAsync', async () => {
-    setItemAsyncMocked.mockResolvedValueOnce()
-    readAsStringAsyncMocked.mockReturnValueOnce(null)
-    writeAsStringAsyncMocked.mockRejectedValueOnce('writeAsStringAsync error')
+    (setItemAsync as jest.Mock).mockResolvedValueOnce(undefined);
+    (readAsStringAsync as jest.Mock).mockReturnValueOnce(null);
+    (writeAsStringAsync as jest.Mock).mockRejectedValueOnce('writeAsStringAsync error');
     await expect(setItem('foo', 'bar')).rejects.toEqual(
       'writeAsStringAsync error'
     )
   })
 
   it('getItem to reject when exception occurs in readAsStringAsync', async () => {
-    readAsStringAsyncMocked.mockRejectedValueOnce('readAsStringAsync error')
+    (readAsStringAsync as jest.Mock).mockRejectedValueOnce('readAsStringAsync error');
     await expect(getItem('foo')).rejects.toEqual('readAsStringAsync error')
   })
 
   it('getItem to reject when getItemAsync returns null', async () => {
-    readAsStringAsyncMocked.mockResolvedValueOnce('encrypted_storage_key')
-    getItemAsyncMocked.mockResolvedValueOnce(null)
+    (readAsStringAsync as jest.Mock).mockResolvedValueOnce('encrypted_storage_key');
+    (getItemAsync as jest.Mock).mockResolvedValueOnce(null);
     await expect(getItem('foo')).rejects.toEqual('Storage key not found')
   })
 
-  it('getItem to reject when exception occurs in getItemAsyncMocked', async () => {
-    readAsStringAsyncMocked.mockResolvedValueOnce('encrypted_storage_key')
-    getItemAsyncMocked.mockRejectedValueOnce('getItemAsync error')
+  it('getItem to reject when exception occurs in getItemAsync', async () => {
+    (readAsStringAsync as jest.Mock).mockResolvedValueOnce('encrypted_storage_key');
+    (getItemAsync as jest.Mock).mockRejectedValueOnce('getItemAsync error');
     await expect(getItem('foo')).rejects.toEqual('getItemAsync error')
   })
 })
+

--- a/src/lib/secure-storage/storage.test.tsx
+++ b/src/lib/secure-storage/storage.test.tsx
@@ -1,56 +1,69 @@
-import { writeAsStringAsync, readAsStringAsync, getInfoAsync } from 'expo-file-system'
+import {
+  writeAsStringAsync,
+  readAsStringAsync,
+  getInfoAsync,
+} from 'expo-file-system'
 import { getItemAsync, setItemAsync } from 'expo-secure-store'
- const { setItem, getItem } = jest.requireActual('./storage');
+const { setItem, getItem } = jest.requireActual('./storage')
 
-jest.mock('expo-file-system');
-jest.mock('expo-secure-store');
- 
+jest.mock('expo-file-system')
+jest.mock('expo-secure-store')
+
 describe('storage', () => {
   beforeEach(() => {
-    jest.resetAllMocks();
+    jest.resetAllMocks()
     global.crypto = {
       getRandomValues: jest.fn().mockReturnValue(new Uint8Array(32)),
-    };
-    (getInfoAsync as jest.Mock).mockImplementation(() => ({ exists: true }));
-   })
+    }
+    ;(getInfoAsync as jest.Mock).mockImplementation(() => ({ exists: true }))
+  })
 
   it('setItem to reject when exception occurs in readAsStringAsync', async () => {
-    (readAsStringAsync as jest.Mock).mockRejectedValueOnce('readAsStringAsync error');
+    ;(readAsStringAsync as jest.Mock).mockRejectedValueOnce(
+      'readAsStringAsync error'
+    )
     await expect(setItem('foo', 'bar')).rejects.toEqual(
       'readAsStringAsync error'
     )
   })
 
   it('setItem to reject when exception occurs in setItemAsync', async () => {
-    (setItemAsync as jest.Mock).mockRejectedValueOnce('setItemAsync error');
-    (readAsStringAsync as jest.Mock).mockReturnValueOnce(null);
+    ;(setItemAsync as jest.Mock).mockRejectedValueOnce('setItemAsync error')
+    ;(readAsStringAsync as jest.Mock).mockReturnValueOnce(null)
     await expect(setItem('foo', 'bar')).rejects.toEqual('setItemAsync error')
   })
 
   it('setItem to reject when exception occurs in writeAsStringAsync', async () => {
-    (setItemAsync as jest.Mock).mockResolvedValueOnce(undefined);
-    (readAsStringAsync as jest.Mock).mockReturnValueOnce(null);
-    (writeAsStringAsync as jest.Mock).mockRejectedValueOnce('writeAsStringAsync error');
+    ;(setItemAsync as jest.Mock).mockResolvedValueOnce(undefined)
+    ;(readAsStringAsync as jest.Mock).mockReturnValueOnce(null)
+    ;(writeAsStringAsync as jest.Mock).mockRejectedValueOnce(
+      'writeAsStringAsync error'
+    )
     await expect(setItem('foo', 'bar')).rejects.toEqual(
       'writeAsStringAsync error'
     )
   })
 
   it('getItem to reject when exception occurs in readAsStringAsync', async () => {
-    (readAsStringAsync as jest.Mock).mockRejectedValueOnce('readAsStringAsync error');
+    ;(readAsStringAsync as jest.Mock).mockRejectedValueOnce(
+      'readAsStringAsync error'
+    )
     await expect(getItem('foo')).rejects.toEqual('readAsStringAsync error')
   })
 
   it('getItem to reject when getItemAsync returns null', async () => {
-    (readAsStringAsync as jest.Mock).mockResolvedValueOnce('encrypted_storage_key');
-    (getItemAsync as jest.Mock).mockResolvedValueOnce(null);
+    ;(readAsStringAsync as jest.Mock).mockResolvedValueOnce(
+      'encrypted_storage_key'
+    )
+    ;(getItemAsync as jest.Mock).mockResolvedValueOnce(null)
     await expect(getItem('foo')).rejects.toEqual('Storage key not found')
   })
 
   it('getItem to reject when exception occurs in getItemAsync', async () => {
-    (readAsStringAsync as jest.Mock).mockResolvedValueOnce('encrypted_storage_key');
-    (getItemAsync as jest.Mock).mockRejectedValueOnce('getItemAsync error');
+    ;(readAsStringAsync as jest.Mock).mockResolvedValueOnce(
+      'encrypted_storage_key'
+    )
+    ;(getItemAsync as jest.Mock).mockRejectedValueOnce('getItemAsync error')
     await expect(getItem('foo')).rejects.toEqual('getItemAsync error')
   })
 })
-

--- a/src/lib/secure-storage/storage.ts
+++ b/src/lib/secure-storage/storage.ts
@@ -10,7 +10,7 @@ const storageFileNameURI = `${storageDirectoryURI}secure-file-storage`
 
 const encryptAndStoreKey = async (data: string) => {
   const { encryptedData, encryptionKey } = await encryptWithRandomKey(data)
-  await SecureStore.setItemAsync(storageKey, encryptionKey)
+   await SecureStore.setItemAsync(storageKey, encryptionKey)
 
   return encryptedData
 }

--- a/src/lib/secure-storage/storage.ts
+++ b/src/lib/secure-storage/storage.ts
@@ -10,7 +10,7 @@ const storageFileNameURI = `${storageDirectoryURI}secure-file-storage`
 
 const encryptAndStoreKey = async (data: string) => {
   const { encryptedData, encryptionKey } = await encryptWithRandomKey(data)
-   await SecureStore.setItemAsync(storageKey, encryptionKey)
+  await SecureStore.setItemAsync(storageKey, encryptionKey)
 
   return encryptedData
 }

--- a/src/screens/CreateTokenScreen.test.tsx
+++ b/src/screens/CreateTokenScreen.test.tsx
@@ -3,10 +3,12 @@ import * as Notification from 'expo-notifications'
 import { Subscription } from 'expo-modules-core'
 import { fireEvent } from '@testing-library/react-native'
 import { NativeStackScreenProps } from 'react-native-screens/native-stack'
-import apiFactory, { API } from '../lib/api'
+
+import apiFactory from '../lib/api'
 import { getMockedNavigation, renderWithTheme } from '../../test/utils'
 import { Secret } from '../types'
 import { MainStackParamList } from '../Main'
+
 import { CreateTokenScreen } from './CreateTokenScreen'
 
 const secret: Secret = {
@@ -18,7 +20,7 @@ const secret: Secret = {
   issuer: '',
 }
 
-jest.mock('../lib/api');
+jest.mock('../lib/api')
 
 jest.mock('@react-navigation/core', () => ({
   useIsFocused: jest.fn().mockReturnValue(true),
@@ -55,14 +57,13 @@ describe('CreateTokenScreen', () => {
   const apiGenerateTokenStub = jest.fn()
 
   beforeEach(() => {
-    (apiFactory as jest.Mock).mockReturnValue({
+    ;(apiFactory as jest.Mock).mockReturnValue({
       registerSubscription: registerSubscriptionStub,
       generateToken: apiGenerateTokenStub,
-    });
-
-    (Notification.addNotificationResponseReceivedListener as jest.Mock).mockReturnValue(
-      {} as Subscription
-    );
+    })
+    ;(
+      Notification.addNotificationResponseReceivedListener as jest.Mock
+    ).mockReturnValue({} as Subscription)
   })
 
   afterEach(() => {

--- a/src/screens/CreateTokenScreen.test.tsx
+++ b/src/screens/CreateTokenScreen.test.tsx
@@ -1,15 +1,12 @@
 import React from 'react'
-import { mocked } from 'ts-jest/utils'
 import * as Notification from 'expo-notifications'
 import { Subscription } from 'expo-modules-core'
 import { fireEvent } from '@testing-library/react-native'
 import { NativeStackScreenProps } from 'react-native-screens/native-stack'
-
 import apiFactory, { API } from '../lib/api'
 import { getMockedNavigation, renderWithTheme } from '../../test/utils'
 import { Secret } from '../types'
 import { MainStackParamList } from '../Main'
-
 import { CreateTokenScreen } from './CreateTokenScreen'
 
 const secret: Secret = {
@@ -20,6 +17,8 @@ const secret: Secret = {
   account: 'account',
   issuer: '',
 }
+
+jest.mock('../lib/api');
 
 jest.mock('@react-navigation/core', () => ({
   useIsFocused: jest.fn().mockReturnValue(true),
@@ -51,24 +50,19 @@ jest.mock('../context/SecretsContext', () => {
   }
 })
 
-const apiFactoryMocked = mocked(apiFactory)
-const addNotificationResponseReceivedListenerMocked = mocked(
-  Notification.addNotificationResponseReceivedListener
-)
-
 describe('CreateTokenScreen', () => {
   const registerSubscriptionStub = jest.fn()
   const apiGenerateTokenStub = jest.fn()
 
   beforeEach(() => {
-    apiFactoryMocked.mockReturnValue({
+    (apiFactory as jest.Mock).mockReturnValue({
       registerSubscription: registerSubscriptionStub,
       generateToken: apiGenerateTokenStub,
-    } as unknown as API)
+    });
 
-    addNotificationResponseReceivedListenerMocked.mockReturnValue(
+    (Notification.addNotificationResponseReceivedListener as jest.Mock).mockReturnValue(
       {} as Subscription
-    )
+    );
   })
 
   afterEach(() => {

--- a/src/screens/HomeScreen.test.tsx
+++ b/src/screens/HomeScreen.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { mocked } from 'ts-jest/utils'
 import * as Notification from 'expo-notifications'
 import { Subscription } from 'expo-modules-core'
 
@@ -28,21 +27,18 @@ jest.mock('../lib/otp', () => ({
 
 jest.mock('../hooks/use-push-token', () => () => 'dummy-expo-token')
 
-const useSecretsMocked = mocked(useSecrets)
-const apiFactoryMocked = mocked(apiFactory)
-const addNotificationResponseReceivedListenerMocked = mocked(
-  Notification.addNotificationResponseReceivedListener
-)
+ 
+ 
 
 describe('HomeScreen', () => {
   const registerSubscriptionStub = jest.fn()
 
   beforeEach(() => {
-    apiFactoryMocked.mockReturnValue({
+    (apiFactory as jest.Mock).mockReturnValue({
       registerSubscription: registerSubscriptionStub,
-    } as unknown as API)
+    });
 
-    addNotificationResponseReceivedListenerMocked.mockReturnValue(
+    (Notification.addNotificationResponseReceivedListener as jest.Mock).mockReturnValue(
       {} as Subscription
     )
   })
@@ -62,7 +58,7 @@ describe('HomeScreen', () => {
   })
 
   it('renders secret cards when available', () => {
-    useSecretsMocked.mockReturnValue({
+    (useSecrets as jest.Mock).mockReturnValue({
       secrets: [
         {
           _id: '111',

--- a/src/screens/HomeScreen.test.tsx
+++ b/src/screens/HomeScreen.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import * as Notification from 'expo-notifications'
 import { Subscription } from 'expo-modules-core'
 
-import apiFactory, { API } from '../lib/api'
+import apiFactory from '../lib/api'
 import { getMockedNavigation, renderWithTheme } from '../../test/utils'
 import { useSecrets } from '../context/SecretsContext'
 
@@ -27,20 +27,16 @@ jest.mock('../lib/otp', () => ({
 
 jest.mock('../hooks/use-push-token', () => () => 'dummy-expo-token')
 
- 
- 
-
 describe('HomeScreen', () => {
   const registerSubscriptionStub = jest.fn()
 
   beforeEach(() => {
-    (apiFactory as jest.Mock).mockReturnValue({
+    ;(apiFactory as jest.Mock).mockReturnValue({
       registerSubscription: registerSubscriptionStub,
-    });
-
-    (Notification.addNotificationResponseReceivedListener as jest.Mock).mockReturnValue(
-      {} as Subscription
-    )
+    })
+    ;(
+      Notification.addNotificationResponseReceivedListener as jest.Mock
+    ).mockReturnValue({} as Subscription)
   })
 
   afterEach(() => {
@@ -58,7 +54,7 @@ describe('HomeScreen', () => {
   })
 
   it('renders secret cards when available', () => {
-    (useSecrets as jest.Mock).mockReturnValue({
+    ;(useSecrets as jest.Mock).mockReturnValue({
       secrets: [
         {
           _id: '111',

--- a/src/screens/TokenScreen.test.tsx
+++ b/src/screens/TokenScreen.test.tsx
@@ -1,7 +1,6 @@
 import { NativeStackScreenProps } from 'react-native-screens/native-stack'
 import React from 'react'
 import { fireEvent, waitFor } from '@testing-library/react-native'
-import { mocked } from 'ts-jest/utils'
 import { Alert } from 'react-native'
 
 import { getMockedNavigation, renderWithTheme } from '../../test/utils'
@@ -30,9 +29,6 @@ jest.mock('../lib/api')
 jest.mock('../hooks/use-push-token', () => () => 'dummy-expo-token')
 jest.mock('../context/SecretsContext')
 
-const useSecretsMocked = mocked(useSecrets)
-const apiFactoryMocked = mocked(apiFactory)
-
 // Continue after alert by clicking the confirm button
 jest
   .spyOn(Alert, 'alert')
@@ -47,19 +43,20 @@ describe('TokenScreen', () => {
   const registerSubscriptionStub = jest.fn().mockResolvedValue('a-sub')
 
   beforeEach(() => {
-    useSecretsMocked.mockReturnValue({
+
+    (useSecrets as jest.Mock).mockReturnValue({
       secrets: [secret],
       add: jest.fn(),
       update: updateSecretStub,
       remove: jest.fn(),
       replace: jest.fn(),
-    })
+    });
 
-    apiFactoryMocked.mockReturnValue({
+    (apiFactory as jest.Mock).mockReturnValue({
       generateToken: apiGenerateTokenStub,
       revokeToken: apiRevokeTokenStub,
       registerSubscription: registerSubscriptionStub,
-    } as unknown as API)
+    });
   })
 
   const setup = () => {

--- a/src/screens/TokenScreen.test.tsx
+++ b/src/screens/TokenScreen.test.tsx
@@ -7,7 +7,7 @@ import { getMockedNavigation, renderWithTheme } from '../../test/utils'
 import { MainStackParamList } from '../Main'
 import { Secret } from '../types'
 import { useSecrets } from '../context/SecretsContext'
-import apiFactory, { API } from '../lib/api'
+import apiFactory from '../lib/api'
 
 import { TokenScreen } from './TokenScreen'
 
@@ -43,20 +43,18 @@ describe('TokenScreen', () => {
   const registerSubscriptionStub = jest.fn().mockResolvedValue('a-sub')
 
   beforeEach(() => {
-
-    (useSecrets as jest.Mock).mockReturnValue({
+    ;(useSecrets as jest.Mock).mockReturnValue({
       secrets: [secret],
       add: jest.fn(),
       update: updateSecretStub,
       remove: jest.fn(),
       replace: jest.fn(),
-    });
-
-    (apiFactory as jest.Mock).mockReturnValue({
+    })
+    ;(apiFactory as jest.Mock).mockReturnValue({
       generateToken: apiGenerateTokenStub,
       revokeToken: apiRevokeTokenStub,
       registerSubscription: registerSubscriptionStub,
-    });
+    })
   })
 
   const setup = () => {

--- a/src/screens/TypeScreen.test.tsx
+++ b/src/screens/TypeScreen.test.tsx
@@ -1,14 +1,10 @@
 import React from 'react'
-import { mocked } from 'ts-jest/utils'
 import { fireEvent } from '@testing-library/react-native'
-
 import { getMockedNavigation, renderWithTheme } from '../../test/utils'
 import { useSecrets } from '../context/SecretsContext'
-
 import { TypeScreen } from './TypeScreen'
 
-const useSecretsMocked = mocked(useSecrets)
-
+ 
 describe('TypeScreen', () => {
   afterEach(() => {
     jest.clearAllMocks()
@@ -26,10 +22,11 @@ describe('TypeScreen', () => {
   })
 
   it('does not allow adding secret on button click when input is empty', () => {
-    const addStub = jest.fn()
-    useSecretsMocked.mockReturnValue({
+    const addStub = jest.fn();
+
+    (useSecrets as jest.Mock).mockReturnValue({
       add: addStub,
-    } as unknown as ReturnType<typeof useSecrets>)
+    })
 
     const { getByA11yLabel } = setup()
 
@@ -39,10 +36,11 @@ describe('TypeScreen', () => {
   })
 
   it('calls add secret on button click', () => {
-    const addStub = jest.fn()
-    useSecretsMocked.mockReturnValue({
+    const addStub = jest.fn();
+
+    (useSecrets as jest.Mock).mockReturnValue({
       add: addStub,
-    } as unknown as ReturnType<typeof useSecrets>)
+    })
 
     const { getByA11yLabel } = setup()
 

--- a/src/screens/TypeScreen.test.tsx
+++ b/src/screens/TypeScreen.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
 import { fireEvent } from '@testing-library/react-native'
+
 import { getMockedNavigation, renderWithTheme } from '../../test/utils'
 import { useSecrets } from '../context/SecretsContext'
+
 import { TypeScreen } from './TypeScreen'
 
- 
 describe('TypeScreen', () => {
   afterEach(() => {
     jest.clearAllMocks()
@@ -22,9 +23,9 @@ describe('TypeScreen', () => {
   })
 
   it('does not allow adding secret on button click when input is empty', () => {
-    const addStub = jest.fn();
+    const addStub = jest.fn()
 
-    (useSecrets as jest.Mock).mockReturnValue({
+    ;(useSecrets as jest.Mock).mockReturnValue({
       add: addStub,
     })
 
@@ -36,9 +37,9 @@ describe('TypeScreen', () => {
   })
 
   it('calls add secret on button click', () => {
-    const addStub = jest.fn();
+    const addStub = jest.fn()
 
-    (useSecrets as jest.Mock).mockReturnValue({
+    ;(useSecrets as jest.Mock).mockReturnValue({
       add: addStub,
     })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2129,6 +2129,13 @@
   optionalDependencies:
     node-notifier "^8.0.0"
 
+"@jest/schemas@^28.1.3":
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-28.1.3.tgz#ad8b86a66f11f33619e3d7e1dcddd7f2d40ff905"
+  integrity sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==
+  dependencies:
+    "@sinclair/typebox" "^0.24.1"
+
 "@jest/source-map@^26.6.2":
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-26.6.2.tgz#29af5e1e2e324cafccc936f218309f54ab69d535"
@@ -2221,6 +2228,18 @@
     "@types/istanbul-reports" "^3.0.0"
     "@types/node" "*"
     "@types/yargs" "^16.0.0"
+    chalk "^4.0.0"
+
+"@jest/types@^28.1.3":
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-28.1.3.tgz#b05de80996ff12512bc5ceb1d208285a7d11748b"
+  integrity sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==
+  dependencies:
+    "@jest/schemas" "^28.1.3"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^17.0.8"
     chalk "^4.0.0"
 
 "@jridgewell/gen-mapping@^0.1.0":
@@ -2606,6 +2625,11 @@
   resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
   integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
+"@sinclair/typebox@^0.24.1":
+  version "0.24.21"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.21.tgz#f2e435ac4c1919ae89c2b693a0d4213d09899290"
+  integrity sha512-II2SIjvxBVJmrGkkZYza/BqNjwx3PWROIA8CZ0/Hn7LV0Mv0CVpZxoyHGBVsQqfFLMv9DmArIeRHTwo76bE6oA==
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
@@ -2869,6 +2893,13 @@
   version "16.0.4"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-16.0.4.tgz#26aad98dd2c2a38e421086ea9ad42b9e51642977"
   integrity sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==
+  dependencies:
+    "@types/yargs-parser" "*"
+
+"@types/yargs@^17.0.8":
+  version "17.0.10"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.10.tgz#591522fce85d8739bca7b8bb90d048e4478d186a"
+  integrity sha512-gmEaFwpj/7f/ROdtIlci1R1VYU1J4j95m8T+Tj3iBgiBFKg1foE/PSl93bBd5T9LDXNPo8UlNN6W0qwD8O5OaA==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -5894,6 +5925,11 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6,
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
 
+graceful-fs@^4.2.9:
+  version "4.2.10"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
+  integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
+
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
@@ -7016,7 +7052,7 @@ jest-util@^26.6.2:
     is-ci "^2.0.0"
     micromatch "^4.0.2"
 
-jest-util@^27.0.0, jest-util@^27.3.1:
+jest-util@^27.3.1:
   version "27.4.2"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-27.4.2.tgz#ed95b05b1adfd761e2cda47e0144c6a58e05a621"
   integrity sha512-YuxxpXU6nlMan9qyLuxHaMMOzXAl5aGZWCSzben5DhLHemYQxCc4YK+4L3ZrCutT8GPQ+ui9k5D8rUJoDioMnA==
@@ -7026,6 +7062,18 @@ jest-util@^27.0.0, jest-util@^27.3.1:
     chalk "^4.0.0"
     ci-info "^3.2.0"
     graceful-fs "^4.2.4"
+    picomatch "^2.2.3"
+
+jest-util@^28.0.0:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-28.1.3.tgz#f4f932aa0074f0679943220ff9cbba7e497028b0"
+  integrity sha512-XdqfpHwpcSRko/C35uLYFM2emRAltIIKZiJ9eAmhjsj0CqZMa0p1ib0R5fWIqGhn1a103DebTbpqIaP1qCQ6tQ==
+  dependencies:
+    "@jest/types" "^28.1.3"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    ci-info "^3.2.0"
+    graceful-fs "^4.2.9"
     picomatch "^2.2.3"
 
 jest-validate@^26.5.2, jest-validate@^26.6.2:
@@ -7245,13 +7293,6 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
-json5@2.x, json5@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
-  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
-  dependencies:
-    minimist "^1.2.5"
-
 json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
@@ -7263,6 +7304,13 @@ json5@^1.0.1:
   integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
   dependencies:
     minimist "^1.2.0"
+
+json5@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
+  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
+  dependencies:
+    minimist "^1.2.5"
 
 json5@^2.2.1:
   version "2.2.1"
@@ -10262,19 +10310,19 @@ ts-interface-checker@^0.1.9:
   resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz#784fd3d679722bc103b1b4b8030bcddb5db2a699"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
 
-ts-jest@^27.1.4:
-  version "27.1.4"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-27.1.4.tgz#84d42cf0f4e7157a52e7c64b1492c46330943e00"
-  integrity sha512-qjkZlVPWVctAezwsOD1OPzbZ+k7zA5z3oxII4dGdZo5ggX/PL7kvwTM0pXTr10fAtbiVpJaL3bWd502zAhpgSQ==
+ts-jest@^28.0.7:
+  version "28.0.7"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-28.0.7.tgz#e18757a9e44693da9980a79127e5df5a98b37ac6"
+  integrity sha512-wWXCSmTwBVmdvWrOpYhal79bDpioDy4rTT+0vyUnE3ZzM7LOAAGG9NXwzkEL/a516rQEgnMmS/WKP9jBPCVJyA==
   dependencies:
     bs-logger "0.x"
     fast-json-stable-stringify "2.x"
-    jest-util "^27.0.0"
-    json5 "2.x"
+    jest-util "^28.0.0"
+    json5 "^2.2.1"
     lodash.memoize "4.x"
     make-error "1.x"
     semver "7.x"
-    yargs-parser "20.x"
+    yargs-parser "^21.0.1"
 
 ts-node@^10.7.0:
   version "10.8.0"
@@ -10941,11 +10989,6 @@ yaml@^2.1.1:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.1.1.tgz#1e06fb4ca46e60d9da07e4f786ea370ed3c3cfec"
   integrity sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==
 
-yargs-parser@20.x, yargs-parser@^20.2.2, yargs-parser@^20.2.3:
-  version "20.2.9"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
-  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
-
 yargs-parser@^18.1.2:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
@@ -10953,6 +10996,16 @@ yargs-parser@^18.1.2:
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
+
+yargs-parser@^20.2.2, yargs-parser@^20.2.3:
+  version "20.2.9"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
+  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
+
+yargs-parser@^21.0.1:
+  version "21.0.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.1.tgz#0267f286c877a4f0f728fceb6f8a3e4cb95c6e35"
+  integrity sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==
 
 yargs@^15.1.0, yargs@^15.3.1, yargs@^15.4.1:
   version "15.4.1"


### PR DESCRIPTION
Resolves the issues with upgrading to ts-jest@28.0.7  that you see in the action logs for https://github.com/nearform/optic-expo/pull/599

Main resolution is is removal of ts-jest/utils mocked as this is now built into jest (see https://github.com/kulshekhar/ts-jest/issues/3327)