### PR TITLE
fix: show `add secret` button only on home screen

### DIFF
--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { StyleSheet } from 'react-native'
-import { FAB, Portal } from 'react-native-paper'
+import { FAB } from 'react-native-paper'
 
 import theme from '../lib/theme'
 
@@ -26,27 +26,25 @@ export const Actions: React.FC<ActionsProps> = ({
   const [{ open }, setOpen] = useState(initialState)
 
   return (
-    <Portal>
-      <FAB.Group
-        visible={visible}
-        open={open}
-        accessibilityLabel="show-actions"
-        icon={open ? 'close' : 'plus'}
-        fabStyle={styles.primaryButton}
-        actions={[
-          {
-            icon: 'qrcode',
-            label: 'Scan QR Code',
-            onPress: onScan,
-          },
-          {
-            icon: 'pencil',
-            label: 'Add details manually',
-            onPress: onType,
-          },
-        ]}
-        onStateChange={setOpen}
-      />
-    </Portal>
+    <FAB.Group
+      visible={visible}
+      open={open}
+      accessibilityLabel="show-actions"
+      icon={open ? 'close' : 'plus'}
+      fabStyle={styles.primaryButton}
+      actions={[
+        {
+          icon: 'qrcode',
+          label: 'Scan QR Code',
+          onPress: onScan,
+        },
+        {
+          icon: 'pencil',
+          label: 'Add details manually',
+          onPress: onType,
+        },
+      ]}
+      onStateChange={setOpen}
+    />
   )
 }

--- a/src/screens/HomeScreen.test.tsx.snap.android
+++ b/src/screens/HomeScreen.test.tsx.snap.android
@@ -2321,6 +2321,591 @@ exports[`HomeScreen renders secret cards when available 1`] = `
         </View>
       </View>
     </RCTScrollView>
+    <View
+      pointerEvents="box-none"
+      style={
+        Array [
+          Object {
+            "bottom": 0,
+            "justifyContent": "flex-end",
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        pointerEvents="none"
+        style={
+          Object {
+            "backgroundColor": "rgba(0, 0, 0, 0.5)",
+            "bottom": 0,
+            "left": 0,
+            "opacity": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          }
+        }
+      />
+      <View
+        pointerEvents="box-none"
+        style={
+          Object {
+            "alignItems": "flex-end",
+          }
+        }
+      >
+        <View
+          pointerEvents="none"
+        >
+          <View
+            pointerEvents="none"
+            style={
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "flex-end",
+                  "marginBottom": 16,
+                },
+                Object {
+                  "marginHorizontal": 24,
+                },
+              ]
+            }
+          >
+            <View>
+              <View
+                accessibilityComponentType="button"
+                accessibilityRole="button"
+                accessibilityTraits="button"
+                collapsable={false}
+                style={
+                  Object {
+                    "backgroundColor": "#ffffff",
+                    "borderColor": "rgba(0, 0, 0, 0.12)",
+                    "borderRadius": 5,
+                    "elevation": 2,
+                    "marginHorizontal": 16,
+                    "marginVertical": 8,
+                    "opacity": 0,
+                    "paddingHorizontal": 12,
+                    "paddingVertical": 6,
+                    "shadowColor": "#000000",
+                    "shadowOffset": Object {
+                      "height": 0.75,
+                      "width": 0,
+                    },
+                    "shadowOpacity": 0.24,
+                    "shadowRadius": 1.5,
+                    "transform": Array [
+                      Object {
+                        "scale": 1,
+                      },
+                    ],
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  accessible={true}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    Object {
+                      "flexGrow": 1,
+                      "flexShrink": 1,
+                    }
+                  }
+                >
+                  <Text
+                    index={0}
+                    siblings={
+                      Array [
+                        "withTheme(undefined)",
+                      ]
+                    }
+                    style={
+                      Array [
+                        Object {
+                          "color": "#6D6D68",
+                          "fontFamily": "sans-serif",
+                          "fontWeight": "normal",
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(109, 109, 104, 0.45999999999999996)",
+                        },
+                      ]
+                    }
+                    total={1}
+                  >
+                    Scan QR Code
+                  </Text>
+                </View>
+              </View>
+            </View>
+            <View
+              accessibilityComponentType="button"
+              accessibilityRole="button"
+              accessibilityTraits="button"
+              collapsable={false}
+              pointerEvents="none"
+              style={
+                Object {
+                  "backgroundColor": "#ffffff",
+                  "borderRadius": 28,
+                  "elevation": 6,
+                  "opacity": 0,
+                  "shadowColor": "#000000",
+                  "shadowOffset": Object {
+                    "height": 5,
+                    "width": 0,
+                  },
+                  "shadowOpacity": 0.24,
+                  "shadowRadius": 6,
+                  "transform": Array [
+                    Object {
+                      "scale": 1,
+                    },
+                  ],
+                }
+              }
+            >
+              <View
+                accessibilityLabel="Scan QR Code"
+                accessibilityRole="button"
+                accessibilityState={
+                  Object {
+                    "disabled": false,
+                  }
+                }
+                accessible={true}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  Array [
+                    Object {
+                      "overflow": "hidden",
+                    },
+                    Object {
+                      "borderRadius": 28,
+                    },
+                  ]
+                }
+              >
+                <View
+                  pointerEvents="none"
+                  style={
+                    Array [
+                      Object {
+                        "alignItems": "center",
+                        "flexDirection": "row",
+                        "justifyContent": "center",
+                      },
+                      Object {
+                        "height": 40,
+                        "width": 40,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      Array [
+                        Object {
+                          "alignItems": "center",
+                          "justifyContent": "center",
+                        },
+                        Object {
+                          "height": 24,
+                          "width": 24,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      collapsable={false}
+                      style={
+                        Object {
+                          "bottom": 0,
+                          "left": 0,
+                          "opacity": 1,
+                          "position": "absolute",
+                          "right": 0,
+                          "top": 0,
+                          "transform": Array [
+                            Object {
+                              "rotate": "0deg",
+                            },
+                          ],
+                        }
+                      }
+                    >
+                      <Text />
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            pointerEvents="none"
+            style={
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "flex-end",
+                  "marginBottom": 16,
+                },
+                Object {
+                  "marginHorizontal": 24,
+                },
+              ]
+            }
+          >
+            <View>
+              <View
+                accessibilityComponentType="button"
+                accessibilityRole="button"
+                accessibilityTraits="button"
+                collapsable={false}
+                style={
+                  Object {
+                    "backgroundColor": "#ffffff",
+                    "borderColor": "rgba(0, 0, 0, 0.12)",
+                    "borderRadius": 5,
+                    "elevation": 2,
+                    "marginHorizontal": 16,
+                    "marginVertical": 8,
+                    "opacity": 0,
+                    "paddingHorizontal": 12,
+                    "paddingVertical": 6,
+                    "shadowColor": "#000000",
+                    "shadowOffset": Object {
+                      "height": 0.75,
+                      "width": 0,
+                    },
+                    "shadowOpacity": 0.24,
+                    "shadowRadius": 1.5,
+                    "transform": Array [
+                      Object {
+                        "scale": 1,
+                      },
+                    ],
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  accessible={true}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    Object {
+                      "flexGrow": 1,
+                      "flexShrink": 1,
+                    }
+                  }
+                >
+                  <Text
+                    index={0}
+                    siblings={
+                      Array [
+                        "withTheme(undefined)",
+                      ]
+                    }
+                    style={
+                      Array [
+                        Object {
+                          "color": "#6D6D68",
+                          "fontFamily": "sans-serif",
+                          "fontWeight": "normal",
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(109, 109, 104, 0.45999999999999996)",
+                        },
+                      ]
+                    }
+                    total={1}
+                  >
+                    Add details manually
+                  </Text>
+                </View>
+              </View>
+            </View>
+            <View
+              accessibilityComponentType="button"
+              accessibilityRole="button"
+              accessibilityTraits="button"
+              collapsable={false}
+              pointerEvents="none"
+              style={
+                Object {
+                  "backgroundColor": "#ffffff",
+                  "borderRadius": 28,
+                  "elevation": 6,
+                  "opacity": 0,
+                  "shadowColor": "#000000",
+                  "shadowOffset": Object {
+                    "height": 5,
+                    "width": 0,
+                  },
+                  "shadowOpacity": 0.24,
+                  "shadowRadius": 6,
+                  "transform": Array [
+                    Object {
+                      "scale": 1,
+                    },
+                  ],
+                }
+              }
+            >
+              <View
+                accessibilityLabel="Add details manually"
+                accessibilityRole="button"
+                accessibilityState={
+                  Object {
+                    "disabled": false,
+                  }
+                }
+                accessible={true}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  Array [
+                    Object {
+                      "overflow": "hidden",
+                    },
+                    Object {
+                      "borderRadius": 28,
+                    },
+                  ]
+                }
+              >
+                <View
+                  pointerEvents="none"
+                  style={
+                    Array [
+                      Object {
+                        "alignItems": "center",
+                        "flexDirection": "row",
+                        "justifyContent": "center",
+                      },
+                      Object {
+                        "height": 40,
+                        "width": 40,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      Array [
+                        Object {
+                          "alignItems": "center",
+                          "justifyContent": "center",
+                        },
+                        Object {
+                          "height": 24,
+                          "width": 24,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      collapsable={false}
+                      style={
+                        Object {
+                          "bottom": 0,
+                          "left": 0,
+                          "opacity": 1,
+                          "position": "absolute",
+                          "right": 0,
+                          "top": 0,
+                          "transform": Array [
+                            Object {
+                              "rotate": "0deg",
+                            },
+                          ],
+                        }
+                      }
+                    >
+                      <Text />
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          accessibilityComponentType="button"
+          accessibilityRole="button"
+          accessibilityTraits="button"
+          collapsable={false}
+          pointerEvents="auto"
+          style={
+            Object {
+              "backgroundColor": "#2165E3",
+              "borderRadius": 28,
+              "elevation": 6,
+              "marginBottom": 16,
+              "marginHorizontal": 16,
+              "marginTop": 0,
+              "opacity": 1,
+              "shadowColor": "#000000",
+              "shadowOffset": Object {
+                "height": 5,
+                "width": 0,
+              },
+              "shadowOpacity": 0.24,
+              "shadowRadius": 6,
+              "transform": Array [
+                Object {
+                  "scale": 1,
+                },
+              ],
+            }
+          }
+        >
+          <View
+            accessibilityLabel="show-actions"
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "disabled": false,
+                "expanded": false,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                Object {
+                  "borderRadius": 28,
+                },
+              ]
+            }
+          >
+            <View
+              pointerEvents="none"
+              style={
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "justifyContent": "center",
+                  },
+                  Object {
+                    "height": 56,
+                    "width": 56,
+                  },
+                ]
+              }
+            >
+              <View
+                style={
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "justifyContent": "center",
+                    },
+                    Object {
+                      "height": 24,
+                      "width": 24,
+                    },
+                  ]
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                      "transform": Array [
+                        Object {
+                          "rotate": "0deg",
+                        },
+                      ],
+                    }
+                  }
+                >
+                  <Text />
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
   </View>
 </View>
 `;
@@ -2427,6 +3012,591 @@ exports[`HomeScreen should match snapshot when there are no secrets 1`] = `
         </View>
       </View>
     </RCTScrollView>
+    <View
+      pointerEvents="box-none"
+      style={
+        Array [
+          Object {
+            "bottom": 0,
+            "justifyContent": "flex-end",
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        pointerEvents="none"
+        style={
+          Object {
+            "backgroundColor": "rgba(0, 0, 0, 0.5)",
+            "bottom": 0,
+            "left": 0,
+            "opacity": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          }
+        }
+      />
+      <View
+        pointerEvents="box-none"
+        style={
+          Object {
+            "alignItems": "flex-end",
+          }
+        }
+      >
+        <View
+          pointerEvents="none"
+        >
+          <View
+            pointerEvents="none"
+            style={
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "flex-end",
+                  "marginBottom": 16,
+                },
+                Object {
+                  "marginHorizontal": 24,
+                },
+              ]
+            }
+          >
+            <View>
+              <View
+                accessibilityComponentType="button"
+                accessibilityRole="button"
+                accessibilityTraits="button"
+                collapsable={false}
+                style={
+                  Object {
+                    "backgroundColor": "#ffffff",
+                    "borderColor": "rgba(0, 0, 0, 0.12)",
+                    "borderRadius": 5,
+                    "elevation": 2,
+                    "marginHorizontal": 16,
+                    "marginVertical": 8,
+                    "opacity": 0,
+                    "paddingHorizontal": 12,
+                    "paddingVertical": 6,
+                    "shadowColor": "#000000",
+                    "shadowOffset": Object {
+                      "height": 0.75,
+                      "width": 0,
+                    },
+                    "shadowOpacity": 0.24,
+                    "shadowRadius": 1.5,
+                    "transform": Array [
+                      Object {
+                        "scale": 1,
+                      },
+                    ],
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  accessible={true}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    Object {
+                      "flexGrow": 1,
+                      "flexShrink": 1,
+                    }
+                  }
+                >
+                  <Text
+                    index={0}
+                    siblings={
+                      Array [
+                        "withTheme(undefined)",
+                      ]
+                    }
+                    style={
+                      Array [
+                        Object {
+                          "color": "#6D6D68",
+                          "fontFamily": "sans-serif",
+                          "fontWeight": "normal",
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(109, 109, 104, 0.45999999999999996)",
+                        },
+                      ]
+                    }
+                    total={1}
+                  >
+                    Scan QR Code
+                  </Text>
+                </View>
+              </View>
+            </View>
+            <View
+              accessibilityComponentType="button"
+              accessibilityRole="button"
+              accessibilityTraits="button"
+              collapsable={false}
+              pointerEvents="none"
+              style={
+                Object {
+                  "backgroundColor": "#ffffff",
+                  "borderRadius": 28,
+                  "elevation": 6,
+                  "opacity": 0,
+                  "shadowColor": "#000000",
+                  "shadowOffset": Object {
+                    "height": 5,
+                    "width": 0,
+                  },
+                  "shadowOpacity": 0.24,
+                  "shadowRadius": 6,
+                  "transform": Array [
+                    Object {
+                      "scale": 1,
+                    },
+                  ],
+                }
+              }
+            >
+              <View
+                accessibilityLabel="Scan QR Code"
+                accessibilityRole="button"
+                accessibilityState={
+                  Object {
+                    "disabled": false,
+                  }
+                }
+                accessible={true}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  Array [
+                    Object {
+                      "overflow": "hidden",
+                    },
+                    Object {
+                      "borderRadius": 28,
+                    },
+                  ]
+                }
+              >
+                <View
+                  pointerEvents="none"
+                  style={
+                    Array [
+                      Object {
+                        "alignItems": "center",
+                        "flexDirection": "row",
+                        "justifyContent": "center",
+                      },
+                      Object {
+                        "height": 40,
+                        "width": 40,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      Array [
+                        Object {
+                          "alignItems": "center",
+                          "justifyContent": "center",
+                        },
+                        Object {
+                          "height": 24,
+                          "width": 24,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      collapsable={false}
+                      style={
+                        Object {
+                          "bottom": 0,
+                          "left": 0,
+                          "opacity": 1,
+                          "position": "absolute",
+                          "right": 0,
+                          "top": 0,
+                          "transform": Array [
+                            Object {
+                              "rotate": "0deg",
+                            },
+                          ],
+                        }
+                      }
+                    >
+                      <Text />
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            pointerEvents="none"
+            style={
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "flex-end",
+                  "marginBottom": 16,
+                },
+                Object {
+                  "marginHorizontal": 24,
+                },
+              ]
+            }
+          >
+            <View>
+              <View
+                accessibilityComponentType="button"
+                accessibilityRole="button"
+                accessibilityTraits="button"
+                collapsable={false}
+                style={
+                  Object {
+                    "backgroundColor": "#ffffff",
+                    "borderColor": "rgba(0, 0, 0, 0.12)",
+                    "borderRadius": 5,
+                    "elevation": 2,
+                    "marginHorizontal": 16,
+                    "marginVertical": 8,
+                    "opacity": 0,
+                    "paddingHorizontal": 12,
+                    "paddingVertical": 6,
+                    "shadowColor": "#000000",
+                    "shadowOffset": Object {
+                      "height": 0.75,
+                      "width": 0,
+                    },
+                    "shadowOpacity": 0.24,
+                    "shadowRadius": 1.5,
+                    "transform": Array [
+                      Object {
+                        "scale": 1,
+                      },
+                    ],
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  accessible={true}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    Object {
+                      "flexGrow": 1,
+                      "flexShrink": 1,
+                    }
+                  }
+                >
+                  <Text
+                    index={0}
+                    siblings={
+                      Array [
+                        "withTheme(undefined)",
+                      ]
+                    }
+                    style={
+                      Array [
+                        Object {
+                          "color": "#6D6D68",
+                          "fontFamily": "sans-serif",
+                          "fontWeight": "normal",
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(109, 109, 104, 0.45999999999999996)",
+                        },
+                      ]
+                    }
+                    total={1}
+                  >
+                    Add details manually
+                  </Text>
+                </View>
+              </View>
+            </View>
+            <View
+              accessibilityComponentType="button"
+              accessibilityRole="button"
+              accessibilityTraits="button"
+              collapsable={false}
+              pointerEvents="none"
+              style={
+                Object {
+                  "backgroundColor": "#ffffff",
+                  "borderRadius": 28,
+                  "elevation": 6,
+                  "opacity": 0,
+                  "shadowColor": "#000000",
+                  "shadowOffset": Object {
+                    "height": 5,
+                    "width": 0,
+                  },
+                  "shadowOpacity": 0.24,
+                  "shadowRadius": 6,
+                  "transform": Array [
+                    Object {
+                      "scale": 1,
+                    },
+                  ],
+                }
+              }
+            >
+              <View
+                accessibilityLabel="Add details manually"
+                accessibilityRole="button"
+                accessibilityState={
+                  Object {
+                    "disabled": false,
+                  }
+                }
+                accessible={true}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  Array [
+                    Object {
+                      "overflow": "hidden",
+                    },
+                    Object {
+                      "borderRadius": 28,
+                    },
+                  ]
+                }
+              >
+                <View
+                  pointerEvents="none"
+                  style={
+                    Array [
+                      Object {
+                        "alignItems": "center",
+                        "flexDirection": "row",
+                        "justifyContent": "center",
+                      },
+                      Object {
+                        "height": 40,
+                        "width": 40,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      Array [
+                        Object {
+                          "alignItems": "center",
+                          "justifyContent": "center",
+                        },
+                        Object {
+                          "height": 24,
+                          "width": 24,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      collapsable={false}
+                      style={
+                        Object {
+                          "bottom": 0,
+                          "left": 0,
+                          "opacity": 1,
+                          "position": "absolute",
+                          "right": 0,
+                          "top": 0,
+                          "transform": Array [
+                            Object {
+                              "rotate": "0deg",
+                            },
+                          ],
+                        }
+                      }
+                    >
+                      <Text />
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          accessibilityComponentType="button"
+          accessibilityRole="button"
+          accessibilityTraits="button"
+          collapsable={false}
+          pointerEvents="auto"
+          style={
+            Object {
+              "backgroundColor": "#2165E3",
+              "borderRadius": 28,
+              "elevation": 6,
+              "marginBottom": 16,
+              "marginHorizontal": 16,
+              "marginTop": 0,
+              "opacity": 1,
+              "shadowColor": "#000000",
+              "shadowOffset": Object {
+                "height": 5,
+                "width": 0,
+              },
+              "shadowOpacity": 0.24,
+              "shadowRadius": 6,
+              "transform": Array [
+                Object {
+                  "scale": 1,
+                },
+              ],
+            }
+          }
+        >
+          <View
+            accessibilityLabel="show-actions"
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "disabled": false,
+                "expanded": false,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                Object {
+                  "borderRadius": 28,
+                },
+              ]
+            }
+          >
+            <View
+              pointerEvents="none"
+              style={
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "justifyContent": "center",
+                  },
+                  Object {
+                    "height": 56,
+                    "width": 56,
+                  },
+                ]
+              }
+            >
+              <View
+                style={
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "justifyContent": "center",
+                    },
+                    Object {
+                      "height": 24,
+                      "width": 24,
+                    },
+                  ]
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                      "transform": Array [
+                        Object {
+                          "rotate": "0deg",
+                        },
+                      ],
+                    }
+                  }
+                >
+                  <Text />
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
   </View>
 </View>
 `;

--- a/src/screens/HomeScreen.test.tsx.snap.ios
+++ b/src/screens/HomeScreen.test.tsx.snap.ios
@@ -2321,6 +2321,591 @@ exports[`HomeScreen renders secret cards when available 1`] = `
         </View>
       </View>
     </RCTScrollView>
+    <View
+      pointerEvents="box-none"
+      style={
+        Array [
+          Object {
+            "bottom": 0,
+            "justifyContent": "flex-end",
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        pointerEvents="none"
+        style={
+          Object {
+            "backgroundColor": "rgba(0, 0, 0, 0.5)",
+            "bottom": 0,
+            "left": 0,
+            "opacity": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          }
+        }
+      />
+      <RCTSafeAreaView
+        pointerEvents="box-none"
+        style={
+          Object {
+            "alignItems": "flex-end",
+          }
+        }
+      >
+        <View
+          pointerEvents="none"
+        >
+          <View
+            pointerEvents="none"
+            style={
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "flex-end",
+                  "marginBottom": 16,
+                },
+                Object {
+                  "marginHorizontal": 24,
+                },
+              ]
+            }
+          >
+            <View>
+              <View
+                accessibilityComponentType="button"
+                accessibilityRole="button"
+                accessibilityTraits="button"
+                collapsable={false}
+                style={
+                  Object {
+                    "backgroundColor": "#ffffff",
+                    "borderColor": "rgba(0, 0, 0, 0.12)",
+                    "borderRadius": 5,
+                    "elevation": 2,
+                    "marginHorizontal": 16,
+                    "marginVertical": 8,
+                    "opacity": 0,
+                    "paddingHorizontal": 12,
+                    "paddingVertical": 6,
+                    "shadowColor": "#000000",
+                    "shadowOffset": Object {
+                      "height": 0.75,
+                      "width": 0,
+                    },
+                    "shadowOpacity": 0.24,
+                    "shadowRadius": 1.5,
+                    "transform": Array [
+                      Object {
+                        "scale": 1,
+                      },
+                    ],
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  accessible={true}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    Object {
+                      "flexGrow": 1,
+                      "flexShrink": 1,
+                    }
+                  }
+                >
+                  <Text
+                    index={0}
+                    siblings={
+                      Array [
+                        "withTheme(undefined)",
+                      ]
+                    }
+                    style={
+                      Array [
+                        Object {
+                          "color": "#6D6D68",
+                          "fontFamily": "System",
+                          "fontWeight": "400",
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(109, 109, 104, 0.45999999999999996)",
+                        },
+                      ]
+                    }
+                    total={1}
+                  >
+                    Scan QR Code
+                  </Text>
+                </View>
+              </View>
+            </View>
+            <View
+              accessibilityComponentType="button"
+              accessibilityRole="button"
+              accessibilityTraits="button"
+              collapsable={false}
+              pointerEvents="none"
+              style={
+                Object {
+                  "backgroundColor": "#ffffff",
+                  "borderRadius": 28,
+                  "elevation": 6,
+                  "opacity": 0,
+                  "shadowColor": "#000000",
+                  "shadowOffset": Object {
+                    "height": 5,
+                    "width": 0,
+                  },
+                  "shadowOpacity": 0.24,
+                  "shadowRadius": 6,
+                  "transform": Array [
+                    Object {
+                      "scale": 1,
+                    },
+                  ],
+                }
+              }
+            >
+              <View
+                accessibilityLabel="Scan QR Code"
+                accessibilityRole="button"
+                accessibilityState={
+                  Object {
+                    "disabled": false,
+                  }
+                }
+                accessible={true}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  Array [
+                    Object {
+                      "overflow": "hidden",
+                    },
+                    Object {
+                      "borderRadius": 28,
+                    },
+                  ]
+                }
+              >
+                <View
+                  pointerEvents="none"
+                  style={
+                    Array [
+                      Object {
+                        "alignItems": "center",
+                        "flexDirection": "row",
+                        "justifyContent": "center",
+                      },
+                      Object {
+                        "height": 40,
+                        "width": 40,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      Array [
+                        Object {
+                          "alignItems": "center",
+                          "justifyContent": "center",
+                        },
+                        Object {
+                          "height": 24,
+                          "width": 24,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      collapsable={false}
+                      style={
+                        Object {
+                          "bottom": 0,
+                          "left": 0,
+                          "opacity": 1,
+                          "position": "absolute",
+                          "right": 0,
+                          "top": 0,
+                          "transform": Array [
+                            Object {
+                              "rotate": "0deg",
+                            },
+                          ],
+                        }
+                      }
+                    >
+                      <Text />
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            pointerEvents="none"
+            style={
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "flex-end",
+                  "marginBottom": 16,
+                },
+                Object {
+                  "marginHorizontal": 24,
+                },
+              ]
+            }
+          >
+            <View>
+              <View
+                accessibilityComponentType="button"
+                accessibilityRole="button"
+                accessibilityTraits="button"
+                collapsable={false}
+                style={
+                  Object {
+                    "backgroundColor": "#ffffff",
+                    "borderColor": "rgba(0, 0, 0, 0.12)",
+                    "borderRadius": 5,
+                    "elevation": 2,
+                    "marginHorizontal": 16,
+                    "marginVertical": 8,
+                    "opacity": 0,
+                    "paddingHorizontal": 12,
+                    "paddingVertical": 6,
+                    "shadowColor": "#000000",
+                    "shadowOffset": Object {
+                      "height": 0.75,
+                      "width": 0,
+                    },
+                    "shadowOpacity": 0.24,
+                    "shadowRadius": 1.5,
+                    "transform": Array [
+                      Object {
+                        "scale": 1,
+                      },
+                    ],
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  accessible={true}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    Object {
+                      "flexGrow": 1,
+                      "flexShrink": 1,
+                    }
+                  }
+                >
+                  <Text
+                    index={0}
+                    siblings={
+                      Array [
+                        "withTheme(undefined)",
+                      ]
+                    }
+                    style={
+                      Array [
+                        Object {
+                          "color": "#6D6D68",
+                          "fontFamily": "System",
+                          "fontWeight": "400",
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(109, 109, 104, 0.45999999999999996)",
+                        },
+                      ]
+                    }
+                    total={1}
+                  >
+                    Add details manually
+                  </Text>
+                </View>
+              </View>
+            </View>
+            <View
+              accessibilityComponentType="button"
+              accessibilityRole="button"
+              accessibilityTraits="button"
+              collapsable={false}
+              pointerEvents="none"
+              style={
+                Object {
+                  "backgroundColor": "#ffffff",
+                  "borderRadius": 28,
+                  "elevation": 6,
+                  "opacity": 0,
+                  "shadowColor": "#000000",
+                  "shadowOffset": Object {
+                    "height": 5,
+                    "width": 0,
+                  },
+                  "shadowOpacity": 0.24,
+                  "shadowRadius": 6,
+                  "transform": Array [
+                    Object {
+                      "scale": 1,
+                    },
+                  ],
+                }
+              }
+            >
+              <View
+                accessibilityLabel="Add details manually"
+                accessibilityRole="button"
+                accessibilityState={
+                  Object {
+                    "disabled": false,
+                  }
+                }
+                accessible={true}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  Array [
+                    Object {
+                      "overflow": "hidden",
+                    },
+                    Object {
+                      "borderRadius": 28,
+                    },
+                  ]
+                }
+              >
+                <View
+                  pointerEvents="none"
+                  style={
+                    Array [
+                      Object {
+                        "alignItems": "center",
+                        "flexDirection": "row",
+                        "justifyContent": "center",
+                      },
+                      Object {
+                        "height": 40,
+                        "width": 40,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      Array [
+                        Object {
+                          "alignItems": "center",
+                          "justifyContent": "center",
+                        },
+                        Object {
+                          "height": 24,
+                          "width": 24,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      collapsable={false}
+                      style={
+                        Object {
+                          "bottom": 0,
+                          "left": 0,
+                          "opacity": 1,
+                          "position": "absolute",
+                          "right": 0,
+                          "top": 0,
+                          "transform": Array [
+                            Object {
+                              "rotate": "0deg",
+                            },
+                          ],
+                        }
+                      }
+                    >
+                      <Text />
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          accessibilityComponentType="button"
+          accessibilityRole="button"
+          accessibilityTraits="button"
+          collapsable={false}
+          pointerEvents="auto"
+          style={
+            Object {
+              "backgroundColor": "#2165E3",
+              "borderRadius": 28,
+              "elevation": 6,
+              "marginBottom": 16,
+              "marginHorizontal": 16,
+              "marginTop": 0,
+              "opacity": 1,
+              "shadowColor": "#000000",
+              "shadowOffset": Object {
+                "height": 5,
+                "width": 0,
+              },
+              "shadowOpacity": 0.24,
+              "shadowRadius": 6,
+              "transform": Array [
+                Object {
+                  "scale": 1,
+                },
+              ],
+            }
+          }
+        >
+          <View
+            accessibilityLabel="show-actions"
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "disabled": false,
+                "expanded": false,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                Object {
+                  "borderRadius": 28,
+                },
+              ]
+            }
+          >
+            <View
+              pointerEvents="none"
+              style={
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "justifyContent": "center",
+                  },
+                  Object {
+                    "height": 56,
+                    "width": 56,
+                  },
+                ]
+              }
+            >
+              <View
+                style={
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "justifyContent": "center",
+                    },
+                    Object {
+                      "height": 24,
+                      "width": 24,
+                    },
+                  ]
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                      "transform": Array [
+                        Object {
+                          "rotate": "0deg",
+                        },
+                      ],
+                    }
+                  }
+                >
+                  <Text />
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </RCTSafeAreaView>
+    </View>
   </View>
 </View>
 `;
@@ -2427,6 +3012,591 @@ exports[`HomeScreen should match snapshot when there are no secrets 1`] = `
         </View>
       </View>
     </RCTScrollView>
+    <View
+      pointerEvents="box-none"
+      style={
+        Array [
+          Object {
+            "bottom": 0,
+            "justifyContent": "flex-end",
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        pointerEvents="none"
+        style={
+          Object {
+            "backgroundColor": "rgba(0, 0, 0, 0.5)",
+            "bottom": 0,
+            "left": 0,
+            "opacity": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          }
+        }
+      />
+      <RCTSafeAreaView
+        pointerEvents="box-none"
+        style={
+          Object {
+            "alignItems": "flex-end",
+          }
+        }
+      >
+        <View
+          pointerEvents="none"
+        >
+          <View
+            pointerEvents="none"
+            style={
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "flex-end",
+                  "marginBottom": 16,
+                },
+                Object {
+                  "marginHorizontal": 24,
+                },
+              ]
+            }
+          >
+            <View>
+              <View
+                accessibilityComponentType="button"
+                accessibilityRole="button"
+                accessibilityTraits="button"
+                collapsable={false}
+                style={
+                  Object {
+                    "backgroundColor": "#ffffff",
+                    "borderColor": "rgba(0, 0, 0, 0.12)",
+                    "borderRadius": 5,
+                    "elevation": 2,
+                    "marginHorizontal": 16,
+                    "marginVertical": 8,
+                    "opacity": 0,
+                    "paddingHorizontal": 12,
+                    "paddingVertical": 6,
+                    "shadowColor": "#000000",
+                    "shadowOffset": Object {
+                      "height": 0.75,
+                      "width": 0,
+                    },
+                    "shadowOpacity": 0.24,
+                    "shadowRadius": 1.5,
+                    "transform": Array [
+                      Object {
+                        "scale": 1,
+                      },
+                    ],
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  accessible={true}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    Object {
+                      "flexGrow": 1,
+                      "flexShrink": 1,
+                    }
+                  }
+                >
+                  <Text
+                    index={0}
+                    siblings={
+                      Array [
+                        "withTheme(undefined)",
+                      ]
+                    }
+                    style={
+                      Array [
+                        Object {
+                          "color": "#6D6D68",
+                          "fontFamily": "System",
+                          "fontWeight": "400",
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(109, 109, 104, 0.45999999999999996)",
+                        },
+                      ]
+                    }
+                    total={1}
+                  >
+                    Scan QR Code
+                  </Text>
+                </View>
+              </View>
+            </View>
+            <View
+              accessibilityComponentType="button"
+              accessibilityRole="button"
+              accessibilityTraits="button"
+              collapsable={false}
+              pointerEvents="none"
+              style={
+                Object {
+                  "backgroundColor": "#ffffff",
+                  "borderRadius": 28,
+                  "elevation": 6,
+                  "opacity": 0,
+                  "shadowColor": "#000000",
+                  "shadowOffset": Object {
+                    "height": 5,
+                    "width": 0,
+                  },
+                  "shadowOpacity": 0.24,
+                  "shadowRadius": 6,
+                  "transform": Array [
+                    Object {
+                      "scale": 1,
+                    },
+                  ],
+                }
+              }
+            >
+              <View
+                accessibilityLabel="Scan QR Code"
+                accessibilityRole="button"
+                accessibilityState={
+                  Object {
+                    "disabled": false,
+                  }
+                }
+                accessible={true}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  Array [
+                    Object {
+                      "overflow": "hidden",
+                    },
+                    Object {
+                      "borderRadius": 28,
+                    },
+                  ]
+                }
+              >
+                <View
+                  pointerEvents="none"
+                  style={
+                    Array [
+                      Object {
+                        "alignItems": "center",
+                        "flexDirection": "row",
+                        "justifyContent": "center",
+                      },
+                      Object {
+                        "height": 40,
+                        "width": 40,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      Array [
+                        Object {
+                          "alignItems": "center",
+                          "justifyContent": "center",
+                        },
+                        Object {
+                          "height": 24,
+                          "width": 24,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      collapsable={false}
+                      style={
+                        Object {
+                          "bottom": 0,
+                          "left": 0,
+                          "opacity": 1,
+                          "position": "absolute",
+                          "right": 0,
+                          "top": 0,
+                          "transform": Array [
+                            Object {
+                              "rotate": "0deg",
+                            },
+                          ],
+                        }
+                      }
+                    >
+                      <Text />
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            pointerEvents="none"
+            style={
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "flex-end",
+                  "marginBottom": 16,
+                },
+                Object {
+                  "marginHorizontal": 24,
+                },
+              ]
+            }
+          >
+            <View>
+              <View
+                accessibilityComponentType="button"
+                accessibilityRole="button"
+                accessibilityTraits="button"
+                collapsable={false}
+                style={
+                  Object {
+                    "backgroundColor": "#ffffff",
+                    "borderColor": "rgba(0, 0, 0, 0.12)",
+                    "borderRadius": 5,
+                    "elevation": 2,
+                    "marginHorizontal": 16,
+                    "marginVertical": 8,
+                    "opacity": 0,
+                    "paddingHorizontal": 12,
+                    "paddingVertical": 6,
+                    "shadowColor": "#000000",
+                    "shadowOffset": Object {
+                      "height": 0.75,
+                      "width": 0,
+                    },
+                    "shadowOpacity": 0.24,
+                    "shadowRadius": 1.5,
+                    "transform": Array [
+                      Object {
+                        "scale": 1,
+                      },
+                    ],
+                  }
+                }
+              >
+                <View
+                  accessibilityState={
+                    Object {
+                      "disabled": false,
+                    }
+                  }
+                  accessible={true}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    Object {
+                      "flexGrow": 1,
+                      "flexShrink": 1,
+                    }
+                  }
+                >
+                  <Text
+                    index={0}
+                    siblings={
+                      Array [
+                        "withTheme(undefined)",
+                      ]
+                    }
+                    style={
+                      Array [
+                        Object {
+                          "color": "#6D6D68",
+                          "fontFamily": "System",
+                          "fontWeight": "400",
+                        },
+                        Object {
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "color": "rgba(109, 109, 104, 0.45999999999999996)",
+                        },
+                      ]
+                    }
+                    total={1}
+                  >
+                    Add details manually
+                  </Text>
+                </View>
+              </View>
+            </View>
+            <View
+              accessibilityComponentType="button"
+              accessibilityRole="button"
+              accessibilityTraits="button"
+              collapsable={false}
+              pointerEvents="none"
+              style={
+                Object {
+                  "backgroundColor": "#ffffff",
+                  "borderRadius": 28,
+                  "elevation": 6,
+                  "opacity": 0,
+                  "shadowColor": "#000000",
+                  "shadowOffset": Object {
+                    "height": 5,
+                    "width": 0,
+                  },
+                  "shadowOpacity": 0.24,
+                  "shadowRadius": 6,
+                  "transform": Array [
+                    Object {
+                      "scale": 1,
+                    },
+                  ],
+                }
+              }
+            >
+              <View
+                accessibilityLabel="Add details manually"
+                accessibilityRole="button"
+                accessibilityState={
+                  Object {
+                    "disabled": false,
+                  }
+                }
+                accessible={true}
+                focusable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  Array [
+                    Object {
+                      "overflow": "hidden",
+                    },
+                    Object {
+                      "borderRadius": 28,
+                    },
+                  ]
+                }
+              >
+                <View
+                  pointerEvents="none"
+                  style={
+                    Array [
+                      Object {
+                        "alignItems": "center",
+                        "flexDirection": "row",
+                        "justifyContent": "center",
+                      },
+                      Object {
+                        "height": 40,
+                        "width": 40,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      Array [
+                        Object {
+                          "alignItems": "center",
+                          "justifyContent": "center",
+                        },
+                        Object {
+                          "height": 24,
+                          "width": 24,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      collapsable={false}
+                      style={
+                        Object {
+                          "bottom": 0,
+                          "left": 0,
+                          "opacity": 1,
+                          "position": "absolute",
+                          "right": 0,
+                          "top": 0,
+                          "transform": Array [
+                            Object {
+                              "rotate": "0deg",
+                            },
+                          ],
+                        }
+                      }
+                    >
+                      <Text />
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          accessibilityComponentType="button"
+          accessibilityRole="button"
+          accessibilityTraits="button"
+          collapsable={false}
+          pointerEvents="auto"
+          style={
+            Object {
+              "backgroundColor": "#2165E3",
+              "borderRadius": 28,
+              "elevation": 6,
+              "marginBottom": 16,
+              "marginHorizontal": 16,
+              "marginTop": 0,
+              "opacity": 1,
+              "shadowColor": "#000000",
+              "shadowOffset": Object {
+                "height": 5,
+                "width": 0,
+              },
+              "shadowOpacity": 0.24,
+              "shadowRadius": 6,
+              "transform": Array [
+                Object {
+                  "scale": 1,
+                },
+              ],
+            }
+          }
+        >
+          <View
+            accessibilityLabel="show-actions"
+            accessibilityRole="button"
+            accessibilityState={
+              Object {
+                "disabled": false,
+                "expanded": false,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "overflow": "hidden",
+                },
+                Object {
+                  "borderRadius": 28,
+                },
+              ]
+            }
+          >
+            <View
+              pointerEvents="none"
+              style={
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "justifyContent": "center",
+                  },
+                  Object {
+                    "height": 56,
+                    "width": 56,
+                  },
+                ]
+              }
+            >
+              <View
+                style={
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "justifyContent": "center",
+                    },
+                    Object {
+                      "height": 24,
+                      "width": 24,
+                    },
+                  ]
+                }
+              >
+                <View
+                  collapsable={false}
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "opacity": 1,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                      "transform": Array [
+                        Object {
+                          "rotate": "0deg",
+                        },
+                      ],
+                    }
+                  }
+                >
+                  <Text />
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </RCTSafeAreaView>
+    </View>
   </View>
 </View>
 `;


### PR DESCRIPTION
I removed the `portal` wrapping the `FAB.Group` component so it's rendered at the page where it's being used but according to the react-native-paper docs it could cause z-index issues. I did try a couple of different scenarios (long list of secrets scrolling under the button, trying to use the buttons and dropdowns while close to the FAB) and it all seemed to work fine.

If that's not an acceptable solution I can try to investigate deeper since the logic to show/hide it seems correct (it uses react-navigation's isFocused hook to check whether a page is focused and shows the button only if the homepage is focused).

Closes #831.