### PR TITLE
Use pre-release version of optic-release-automation-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: nearform/optic-release-automation-action@v4
+      - uses: nearform/optic-release-automation-action@feat/add-monorepo-support
         with:
           github-token: ${{ secrets.github_token }}
           semver: ${{ github.event.inputs.semver }}


### PR DESCRIPTION
We're updating this action in a couple of repositories to test it before fully releasing it.

After the test period this should be changed back to the latest version of optic-release-automation-action.

References nearform/optic-release-automation-action#186