### PR TITLE
chore: revert optic-release-automation version to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: nearform/optic-release-automation-action@feat/add-monorepo-support
+      - uses: nearform/optic-release-automation-action@v4
         with:
           github-token: ${{ secrets.github_token }}
           semver: ${{ github.event.inputs.semver }}
@@ -27,4 +27,3 @@ jobs:
           build-command: |
             yarn install --frozen-lockfile
             npm run bump:version
-


### PR DESCRIPTION
Reverts `optic-release-automation-action` to version 4 in the release workflow. Previously, it was testing the WIP on monorepos.