### PR TITLE
chore(deps): bump react-native-paper to 5.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "react-native-crypto-js": "^1.0.0",
     "react-native-gesture-handler": "~2.8.0",
     "react-native-get-random-values": "~1.8.0",
-    "react-native-paper": "5.0.2",
+    "react-native-paper": "5.1.2",
     "react-native-root-toast": "^3.4.0",
     "react-native-safe-area-context": "4.4.1",
     "react-native-screens": "~3.18.0",

--- a/src/screens/ExportFileSecret.test.tsx.snap.android
+++ b/src/screens/ExportFileSecret.test.tsx.snap.android
@@ -279,7 +279,6 @@ exports[`ExportFileSecret should match snapshot 1`] = `
                 style={
                   Array [
                     Object {
-                      "flexGrow": 1,
                       "margin": 0,
                       "zIndex": 1,
                     },
@@ -304,6 +303,7 @@ exports[`ExportFileSecret should match snapshot 1`] = `
                     Array [
                       Object {},
                     ],
+                    undefined,
                   ]
                 }
                 testID="text-input-outlined"
@@ -367,6 +367,7 @@ exports[`ExportFileSecret should match snapshot 1`] = `
                 },
               ]
             }
+            testID="button"
           >
             <View
               style={
@@ -391,6 +392,7 @@ exports[`ExportFileSecret should match snapshot 1`] = `
                     false,
                   ]
                 }
+                testID="button-icon-container"
               >
                 <Text />
               </View>

--- a/src/screens/ExportFileSecret.test.tsx.snap.ios
+++ b/src/screens/ExportFileSecret.test.tsx.snap.ios
@@ -279,7 +279,6 @@ exports[`ExportFileSecret should match snapshot 1`] = `
                 style={
                   Array [
                     Object {
-                      "flexGrow": 1,
                       "margin": 0,
                       "zIndex": 1,
                     },
@@ -304,6 +303,7 @@ exports[`ExportFileSecret should match snapshot 1`] = `
                     Array [
                       Object {},
                     ],
+                    undefined,
                   ]
                 }
                 testID="text-input-outlined"
@@ -367,6 +367,7 @@ exports[`ExportFileSecret should match snapshot 1`] = `
                 },
               ]
             }
+            testID="button"
           >
             <View
               style={
@@ -391,6 +392,7 @@ exports[`ExportFileSecret should match snapshot 1`] = `
                     false,
                   ]
                 }
+                testID="button-icon-container"
               >
                 <Text />
               </View>

--- a/src/screens/HomeScreen.test.tsx.snap.android
+++ b/src/screens/HomeScreen.test.tsx.snap.android
@@ -82,6 +82,7 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                     "flexShrink": 1,
                   }
                 }
+                testID="card"
               >
                 <View
                   style={
@@ -326,11 +327,16 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                                 "overflow": "hidden",
                               },
                               false,
-                              Object {
-                                "alignItems": "center",
-                                "flexGrow": 1,
-                                "justifyContent": "center",
-                              },
+                              Array [
+                                Object {
+                                  "alignItems": "center",
+                                  "flexGrow": 1,
+                                  "justifyContent": "center",
+                                },
+                                Object {
+                                  "borderRadius": 18,
+                                },
+                              ],
                             ]
                           }
                         >
@@ -485,11 +491,16 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                                   "overflow": "hidden",
                                 },
                                 false,
-                                Object {
-                                  "alignItems": "center",
-                                  "flexGrow": 1,
-                                  "justifyContent": "center",
-                                },
+                                Array [
+                                  Object {
+                                    "alignItems": "center",
+                                    "flexGrow": 1,
+                                    "justifyContent": "center",
+                                  },
+                                  Object {
+                                    "borderRadius": 15,
+                                  },
+                                ],
                               ]
                             }
                           >
@@ -784,6 +795,7 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                               },
                             ]
                           }
+                          testID="button"
                         >
                           <View
                             style={
@@ -810,6 +822,7 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                                   false,
                                 ]
                               }
+                              testID="button-icon-container"
                             >
                               <Text />
                             </View>
@@ -1054,6 +1067,7 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                             },
                           ]
                         }
+                        testID="button"
                       >
                         <View
                           style={
@@ -1078,6 +1092,7 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                                 false,
                               ]
                             }
+                            testID="button-icon-container"
                           >
                             <Text />
                           </View>
@@ -1185,6 +1200,7 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                             },
                           ]
                         }
+                        testID="button"
                       >
                         <View
                           style={
@@ -1209,6 +1225,7 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                                 false,
                               ]
                             }
+                            testID="button-icon-container"
                           >
                             <Text />
                           </View>
@@ -1306,6 +1323,7 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                     "flexShrink": 1,
                   }
                 }
+                testID="card"
               >
                 <View
                   style={
@@ -1550,11 +1568,16 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                                 "overflow": "hidden",
                               },
                               false,
-                              Object {
-                                "alignItems": "center",
-                                "flexGrow": 1,
-                                "justifyContent": "center",
-                              },
+                              Array [
+                                Object {
+                                  "alignItems": "center",
+                                  "flexGrow": 1,
+                                  "justifyContent": "center",
+                                },
+                                Object {
+                                  "borderRadius": 18,
+                                },
+                              ],
                             ]
                           }
                         >
@@ -1709,11 +1732,16 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                                   "overflow": "hidden",
                                 },
                                 false,
-                                Object {
-                                  "alignItems": "center",
-                                  "flexGrow": 1,
-                                  "justifyContent": "center",
-                                },
+                                Array [
+                                  Object {
+                                    "alignItems": "center",
+                                    "flexGrow": 1,
+                                    "justifyContent": "center",
+                                  },
+                                  Object {
+                                    "borderRadius": 15,
+                                  },
+                                ],
                               ]
                             }
                           >
@@ -2008,6 +2036,7 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                               },
                             ]
                           }
+                          testID="button"
                         >
                           <View
                             style={
@@ -2034,6 +2063,7 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                                   false,
                                 ]
                               }
+                              testID="button-icon-container"
                             >
                               <Text />
                             </View>
@@ -2278,6 +2308,7 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                             },
                           ]
                         }
+                        testID="button"
                       >
                         <View
                           style={
@@ -2302,6 +2333,7 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                                 false,
                               ]
                             }
+                            testID="button-icon-container"
                           >
                             <Text />
                           </View>
@@ -2409,6 +2441,7 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                             },
                           ]
                         }
+                        testID="button"
                       >
                         <View
                           style={
@@ -2433,6 +2466,7 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                                 false,
                               ]
                             }
+                            testID="button-icon-container"
                           >
                             <Text />
                           </View>
@@ -2612,6 +2646,7 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                         "flexShrink": 1,
                       }
                     }
+                    testID="card"
                   >
                     <Text
                       index={0}
@@ -2824,6 +2859,7 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                         "flexShrink": 1,
                       }
                     }
+                    testID="card"
                   >
                     <Text
                       index={0}
@@ -3338,6 +3374,7 @@ exports[`HomeScreen should match snapshot when there are no secrets 1`] = `
                         "flexShrink": 1,
                       }
                     }
+                    testID="card"
                   >
                     <Text
                       index={0}
@@ -3550,6 +3587,7 @@ exports[`HomeScreen should match snapshot when there are no secrets 1`] = `
                         "flexShrink": 1,
                       }
                     }
+                    testID="card"
                   >
                     <Text
                       index={0}

--- a/src/screens/HomeScreen.test.tsx.snap.ios
+++ b/src/screens/HomeScreen.test.tsx.snap.ios
@@ -82,6 +82,7 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                     "flexShrink": 1,
                   }
                 }
+                testID="card"
               >
                 <View
                   style={
@@ -326,11 +327,16 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                                 "overflow": "hidden",
                               },
                               false,
-                              Object {
-                                "alignItems": "center",
-                                "flexGrow": 1,
-                                "justifyContent": "center",
-                              },
+                              Array [
+                                Object {
+                                  "alignItems": "center",
+                                  "flexGrow": 1,
+                                  "justifyContent": "center",
+                                },
+                                Object {
+                                  "borderRadius": 18,
+                                },
+                              ],
                             ]
                           }
                         >
@@ -485,11 +491,16 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                                   "overflow": "hidden",
                                 },
                                 false,
-                                Object {
-                                  "alignItems": "center",
-                                  "flexGrow": 1,
-                                  "justifyContent": "center",
-                                },
+                                Array [
+                                  Object {
+                                    "alignItems": "center",
+                                    "flexGrow": 1,
+                                    "justifyContent": "center",
+                                  },
+                                  Object {
+                                    "borderRadius": 15,
+                                  },
+                                ],
                               ]
                             }
                           >
@@ -784,6 +795,7 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                               },
                             ]
                           }
+                          testID="button"
                         >
                           <View
                             style={
@@ -810,6 +822,7 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                                   false,
                                 ]
                               }
+                              testID="button-icon-container"
                             >
                               <Text />
                             </View>
@@ -1054,6 +1067,7 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                             },
                           ]
                         }
+                        testID="button"
                       >
                         <View
                           style={
@@ -1078,6 +1092,7 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                                 false,
                               ]
                             }
+                            testID="button-icon-container"
                           >
                             <Text />
                           </View>
@@ -1185,6 +1200,7 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                             },
                           ]
                         }
+                        testID="button"
                       >
                         <View
                           style={
@@ -1209,6 +1225,7 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                                 false,
                               ]
                             }
+                            testID="button-icon-container"
                           >
                             <Text />
                           </View>
@@ -1306,6 +1323,7 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                     "flexShrink": 1,
                   }
                 }
+                testID="card"
               >
                 <View
                   style={
@@ -1550,11 +1568,16 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                                 "overflow": "hidden",
                               },
                               false,
-                              Object {
-                                "alignItems": "center",
-                                "flexGrow": 1,
-                                "justifyContent": "center",
-                              },
+                              Array [
+                                Object {
+                                  "alignItems": "center",
+                                  "flexGrow": 1,
+                                  "justifyContent": "center",
+                                },
+                                Object {
+                                  "borderRadius": 18,
+                                },
+                              ],
                             ]
                           }
                         >
@@ -1709,11 +1732,16 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                                   "overflow": "hidden",
                                 },
                                 false,
-                                Object {
-                                  "alignItems": "center",
-                                  "flexGrow": 1,
-                                  "justifyContent": "center",
-                                },
+                                Array [
+                                  Object {
+                                    "alignItems": "center",
+                                    "flexGrow": 1,
+                                    "justifyContent": "center",
+                                  },
+                                  Object {
+                                    "borderRadius": 15,
+                                  },
+                                ],
                               ]
                             }
                           >
@@ -2008,6 +2036,7 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                               },
                             ]
                           }
+                          testID="button"
                         >
                           <View
                             style={
@@ -2034,6 +2063,7 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                                   false,
                                 ]
                               }
+                              testID="button-icon-container"
                             >
                               <Text />
                             </View>
@@ -2278,6 +2308,7 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                             },
                           ]
                         }
+                        testID="button"
                       >
                         <View
                           style={
@@ -2302,6 +2333,7 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                                 false,
                               ]
                             }
+                            testID="button-icon-container"
                           >
                             <Text />
                           </View>
@@ -2409,6 +2441,7 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                             },
                           ]
                         }
+                        testID="button"
                       >
                         <View
                           style={
@@ -2433,6 +2466,7 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                                 false,
                               ]
                             }
+                            testID="button-icon-container"
                           >
                             <Text />
                           </View>
@@ -2612,6 +2646,7 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                         "flexShrink": 1,
                       }
                     }
+                    testID="card"
                   >
                     <Text
                       index={0}
@@ -2824,6 +2859,7 @@ exports[`HomeScreen renders secret cards when available 1`] = `
                         "flexShrink": 1,
                       }
                     }
+                    testID="card"
                   >
                     <Text
                       index={0}
@@ -3338,6 +3374,7 @@ exports[`HomeScreen should match snapshot when there are no secrets 1`] = `
                         "flexShrink": 1,
                       }
                     }
+                    testID="card"
                   >
                     <Text
                       index={0}
@@ -3550,6 +3587,7 @@ exports[`HomeScreen should match snapshot when there are no secrets 1`] = `
                         "flexShrink": 1,
                       }
                     }
+                    testID="card"
                   >
                     <Text
                       index={0}

--- a/src/screens/ImportFileSecret.test.tsx.snap.android
+++ b/src/screens/ImportFileSecret.test.tsx.snap.android
@@ -279,7 +279,6 @@ exports[`ImportFileSecret should match snapshot 1`] = `
                 style={
                   Array [
                     Object {
-                      "flexGrow": 1,
                       "margin": 0,
                       "zIndex": 1,
                     },
@@ -304,6 +303,7 @@ exports[`ImportFileSecret should match snapshot 1`] = `
                     Array [
                       Object {},
                     ],
+                    undefined,
                   ]
                 }
                 testID="text-input-outlined"
@@ -367,6 +367,7 @@ exports[`ImportFileSecret should match snapshot 1`] = `
                 },
               ]
             }
+            testID="button"
           >
             <View
               style={
@@ -391,6 +392,7 @@ exports[`ImportFileSecret should match snapshot 1`] = `
                     false,
                   ]
                 }
+                testID="button-icon-container"
               >
                 <Text />
               </View>

--- a/src/screens/ImportFileSecret.test.tsx.snap.ios
+++ b/src/screens/ImportFileSecret.test.tsx.snap.ios
@@ -279,7 +279,6 @@ exports[`ImportFileSecret should match snapshot 1`] = `
                 style={
                   Array [
                     Object {
-                      "flexGrow": 1,
                       "margin": 0,
                       "zIndex": 1,
                     },
@@ -304,6 +303,7 @@ exports[`ImportFileSecret should match snapshot 1`] = `
                     Array [
                       Object {},
                     ],
+                    undefined,
                   ]
                 }
                 testID="text-input-outlined"
@@ -367,6 +367,7 @@ exports[`ImportFileSecret should match snapshot 1`] = `
                 },
               ]
             }
+            testID="button"
           >
             <View
               style={
@@ -391,6 +392,7 @@ exports[`ImportFileSecret should match snapshot 1`] = `
                     false,
                   ]
                 }
+                testID="button-icon-container"
               >
                 <Text />
               </View>

--- a/src/screens/SettingsScreen.test.tsx.snap.android
+++ b/src/screens/SettingsScreen.test.tsx.snap.android
@@ -198,6 +198,7 @@ exports[`SettingsScreen should match snapshot 1`] = `
                       },
                     ]
                   }
+                  testID="button"
                 >
                   <View
                     style={
@@ -222,6 +223,7 @@ exports[`SettingsScreen should match snapshot 1`] = `
                           false,
                         ]
                       }
+                      testID="button-icon-container"
                     >
                       <Text />
                     </View>
@@ -368,6 +370,7 @@ exports[`SettingsScreen should match snapshot 1`] = `
                       },
                     ]
                   }
+                  testID="button"
                 >
                   <View
                     style={
@@ -392,6 +395,7 @@ exports[`SettingsScreen should match snapshot 1`] = `
                           false,
                         ]
                       }
+                      testID="button-icon-container"
                     >
                       <Text />
                     </View>
@@ -544,6 +548,7 @@ exports[`SettingsScreen should match snapshot 1`] = `
                       },
                     ]
                   }
+                  testID="button"
                 >
                   <View
                     style={
@@ -655,6 +660,7 @@ exports[`SettingsScreen should match snapshot 1`] = `
                       },
                     ]
                   }
+                  testID="button"
                 >
                   <View
                     style={

--- a/src/screens/SettingsScreen.test.tsx.snap.ios
+++ b/src/screens/SettingsScreen.test.tsx.snap.ios
@@ -197,6 +197,7 @@ exports[`SettingsScreen should match snapshot 1`] = `
                       },
                     ]
                   }
+                  testID="button"
                 >
                   <View
                     style={
@@ -221,6 +222,7 @@ exports[`SettingsScreen should match snapshot 1`] = `
                           false,
                         ]
                       }
+                      testID="button-icon-container"
                     >
                       <Text />
                     </View>
@@ -367,6 +369,7 @@ exports[`SettingsScreen should match snapshot 1`] = `
                       },
                     ]
                   }
+                  testID="button"
                 >
                   <View
                     style={
@@ -391,6 +394,7 @@ exports[`SettingsScreen should match snapshot 1`] = `
                           false,
                         ]
                       }
+                      testID="button-icon-container"
                     >
                       <Text />
                     </View>
@@ -543,6 +547,7 @@ exports[`SettingsScreen should match snapshot 1`] = `
                       },
                     ]
                   }
+                  testID="button"
                 >
                   <View
                     style={
@@ -654,6 +659,7 @@ exports[`SettingsScreen should match snapshot 1`] = `
                       },
                     ]
                   }
+                  testID="button"
                 >
                   <View
                     style={

--- a/src/screens/TypeScreen.test.tsx.snap.android
+++ b/src/screens/TypeScreen.test.tsx.snap.android
@@ -250,7 +250,6 @@ exports[`TypeScreen should match snapshot 1`] = `
                   style={
                     Array [
                       Object {
-                        "flexGrow": 1,
                         "margin": 0,
                         "zIndex": 1,
                       },
@@ -275,6 +274,7 @@ exports[`TypeScreen should match snapshot 1`] = `
                       Array [
                         Object {},
                       ],
+                      undefined,
                     ]
                   }
                   testID="text-input-outlined"
@@ -500,7 +500,6 @@ exports[`TypeScreen should match snapshot 1`] = `
                   style={
                     Array [
                       Object {
-                        "flexGrow": 1,
                         "margin": 0,
                         "zIndex": 1,
                       },
@@ -525,6 +524,7 @@ exports[`TypeScreen should match snapshot 1`] = `
                       Array [
                         Object {},
                       ],
+                      undefined,
                     ]
                   }
                   testID="text-input-outlined"
@@ -754,7 +754,6 @@ exports[`TypeScreen should match snapshot 1`] = `
                   style={
                     Array [
                       Object {
-                        "flexGrow": 1,
                         "margin": 0,
                         "zIndex": 1,
                       },
@@ -779,6 +778,7 @@ exports[`TypeScreen should match snapshot 1`] = `
                       Array [
                         Object {},
                       ],
+                      undefined,
                     ]
                   }
                   testID="text-input-outlined"
@@ -845,6 +845,7 @@ exports[`TypeScreen should match snapshot 1`] = `
                 },
               ]
             }
+            testID="button"
           >
             <View
               style={
@@ -869,6 +870,7 @@ exports[`TypeScreen should match snapshot 1`] = `
                     false,
                   ]
                 }
+                testID="button-icon-container"
               >
                 <Text />
               </View>

--- a/src/screens/TypeScreen.test.tsx.snap.ios
+++ b/src/screens/TypeScreen.test.tsx.snap.ios
@@ -250,7 +250,6 @@ exports[`TypeScreen should match snapshot 1`] = `
                   style={
                     Array [
                       Object {
-                        "flexGrow": 1,
                         "margin": 0,
                         "zIndex": 1,
                       },
@@ -275,6 +274,7 @@ exports[`TypeScreen should match snapshot 1`] = `
                       Array [
                         Object {},
                       ],
+                      undefined,
                     ]
                   }
                   testID="text-input-outlined"
@@ -500,7 +500,6 @@ exports[`TypeScreen should match snapshot 1`] = `
                   style={
                     Array [
                       Object {
-                        "flexGrow": 1,
                         "margin": 0,
                         "zIndex": 1,
                       },
@@ -525,6 +524,7 @@ exports[`TypeScreen should match snapshot 1`] = `
                       Array [
                         Object {},
                       ],
+                      undefined,
                     ]
                   }
                   testID="text-input-outlined"
@@ -754,7 +754,6 @@ exports[`TypeScreen should match snapshot 1`] = `
                   style={
                     Array [
                       Object {
-                        "flexGrow": 1,
                         "margin": 0,
                         "zIndex": 1,
                       },
@@ -779,6 +778,7 @@ exports[`TypeScreen should match snapshot 1`] = `
                       Array [
                         Object {},
                       ],
+                      undefined,
                     ]
                   }
                   testID="text-input-outlined"
@@ -845,6 +845,7 @@ exports[`TypeScreen should match snapshot 1`] = `
                 },
               ]
             }
+            testID="button"
           >
             <View
               style={
@@ -869,6 +870,7 @@ exports[`TypeScreen should match snapshot 1`] = `
                     false,
                   ]
                 }
+                testID="button-icon-container"
               >
                 <Text />
               </View>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9392,10 +9392,10 @@ react-native-gradle-plugin@^0.70.3:
   resolved "https://registry.yarnpkg.com/react-native-gradle-plugin/-/react-native-gradle-plugin-0.70.3.tgz#cbcf0619cbfbddaa9128701aa2d7b4145f9c4fc8"
   integrity sha512-oOanj84fJEXUg9FoEAQomA8ISG+DVIrTZ3qF7m69VQUJyOGYyDZmPqKcjvRku4KXlEH6hWO9i4ACLzNBh8gC0A==
 
-react-native-paper@5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/react-native-paper/-/react-native-paper-5.0.2.tgz#1ea77d394988c0b8be9e933a1a7f6c16a180adc5"
-  integrity sha512-PRH2QtlpXovfbs82affDQO9BT7vK3lKa04daK56ov3YXezPmbJnPy1dAAyERrLUswtxyY/e6dQhnIMkkKg3k0Q==
+react-native-paper@5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/react-native-paper/-/react-native-paper-5.1.2.tgz#695e273871b17b908299029adadb72492271e586"
+  integrity sha512-muf70CPtji6gTukV+9ecvzOYFOflK2hi4t4GLt9y4Ynhf/YQCvXsefPTp45n7RS6bz9+ueG4jtuGg64oOY8dxA==
   dependencies:
     "@callstack/react-theme-provider" "^3.0.8"
     color "^3.1.2"


### PR DESCRIPTION
replacing this other PR: https://github.com/nearform/optic-expo/pull/909