### PR TITLE
added production track to android

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -24,6 +24,9 @@
     "production": {
       "ios": {
         "ascAppId": "1643969791"
+      },
+      "android": {
+        "track": "production"
       }
     }
   }


### PR DESCRIPTION
This is to ensure that android deployments are released to immediately to users without having to go through the manual process of creating a production release on the play store.
fixes #1245 