### PR TITLE
fix: allows OTP to be approved from a cold start

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import theme from './lib/theme'
 import Main from './Main'
 import { PrefsProvider } from './context/PrefsContext'
 import { PendingNotificationsProvider } from './context/PendingNotificationsContext'
+import { InitialLoadingProvider } from './context/InitalLoadingContext'
 
 export default function App() {
   return (
@@ -18,10 +19,12 @@ export default function App() {
         <SecretsProvider>
           <PrefsProvider>
             <PendingNotificationsProvider>
-              <PaperProvider theme={theme}>
-                <Main />
-                <StatusBar style="auto" />
-              </PaperProvider>
+              <InitialLoadingProvider>
+                <PaperProvider theme={theme}>
+                  <Main />
+                  <StatusBar style="auto" />
+                </PaperProvider>
+              </InitialLoadingProvider>
             </PendingNotificationsProvider>
           </PrefsProvider>
         </SecretsProvider>

--- a/src/context/InitalLoadingContext.tsx
+++ b/src/context/InitalLoadingContext.tsx
@@ -1,4 +1,10 @@
-import React, { createContext, useContext, useState } from 'react'
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useMemo,
+  useCallback,
+} from 'react'
 
 const initialContext = {
   initialLoadingComplete: false,
@@ -14,14 +20,20 @@ export const useInitialLoading = () => useContext(InitialLoadingContext)
 export const InitialLoadingProvider = ({ children }) => {
   const [initialLoadingComplete, setInitialLoadingComplete] = useState(false)
 
-  const markInitialLoadingComplete = () => {
+  const markInitialLoadingComplete = useCallback(() => {
     setInitialLoadingComplete(true)
-  }
+  }, [setInitialLoadingComplete])
+
+  const value = useMemo(
+    () => ({
+      initialLoadingComplete,
+      markInitialLoadingComplete,
+    }),
+    [initialLoadingComplete, markInitialLoadingComplete]
+  )
 
   return (
-    <InitialLoadingContext.Provider
-      value={{ initialLoadingComplete, markInitialLoadingComplete }}
-    >
+    <InitialLoadingContext.Provider value={value}>
       {children}
     </InitialLoadingContext.Provider>
   )

--- a/src/context/InitalLoadingContext.tsx
+++ b/src/context/InitalLoadingContext.tsx
@@ -1,0 +1,28 @@
+import React, { createContext, useContext, useState } from 'react'
+
+const initialContext = {
+  initialLoadingComplete: false,
+  markInitialLoadingComplete: () => {
+    // set in context provider construction
+  },
+}
+
+const InitialLoadingContext = createContext(initialContext)
+
+export const useInitialLoading = () => useContext(InitialLoadingContext)
+
+export const InitialLoadingProvider = ({ children }) => {
+  const [initialLoadingComplete, setInitialLoadingComplete] = useState(false)
+
+  const markInitialLoadingComplete = () => {
+    setInitialLoadingComplete(true)
+  }
+
+  return (
+    <InitialLoadingContext.Provider
+      value={{ initialLoadingComplete, markInitialLoadingComplete }}
+    >
+      {children}
+    </InitialLoadingContext.Provider>
+  )
+}

--- a/src/screens/HomeScreen.test.tsx
+++ b/src/screens/HomeScreen.test.tsx
@@ -17,6 +17,7 @@ jest.mock('expo-notifications', () => ({
   addNotificationReceivedListener: jest.fn(),
   addNotificationResponseReceivedListener: jest.fn(),
   removeNotificationSubscription: jest.fn(),
+  useLastNotificationResponse: jest.fn(),
 }))
 
 jest.mock('../lib/api')

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -113,6 +113,21 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
   )
 
   useEffect(() => {
+    notificationListener.current =
+      Notifications.addNotificationReceivedListener(onNotification)
+
+    responseListener.current =
+      Notifications.addNotificationResponseReceivedListener(
+        onNotificationResponse
+      )
+
+    return () => {
+      Notifications.removeNotificationSubscription(responseListener.current)
+      Notifications.removeNotificationSubscription(notificationListener.current)
+    }
+  }, [onNotification, onNotificationResponse])
+
+  useEffect(() => {
     // runs callbacks when notification is pressed from a cold start
     if (
       !initialLoadingComplete &&
@@ -131,21 +146,8 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
       onNotificationResponse(lastNotificationResponse)
       onNotification(opticNotification)
 
-      // prevents the cold start callbacks from being called after a notification is triggered
+      // prevents the cold start callbacks from being called again after this conditional has been triggered
       setInitialLoadingComplete(true)
-    }
-
-    notificationListener.current =
-      Notifications.addNotificationReceivedListener(onNotification)
-
-    responseListener.current =
-      Notifications.addNotificationResponseReceivedListener(
-        onNotificationResponse
-      )
-
-    return () => {
-      Notifications.removeNotificationSubscription(responseListener.current)
-      Notifications.removeNotificationSubscription(notificationListener.current)
     }
   }, [
     initialLoadingComplete,

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef } from 'react'
 import * as Notifications from 'expo-notifications'
 import { NotificationResponse } from 'expo-notifications'
 import { ScrollView, StyleSheet, View } from 'react-native'
@@ -10,6 +10,7 @@ import Toast from 'react-native-root-toast'
 import { usePendingNotifications } from '../context/PendingNotificationsContext'
 import { useSecrets } from '../context/SecretsContext'
 import { useAuth } from '../context/AuthContext'
+import { useInitialLoading } from '../context/InitalLoadingContext'
 import apiFactory from '../lib/api'
 import { NoSecrets } from '../components/NoSecrets'
 import { Actions } from '../components/Actions'
@@ -48,7 +49,8 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
   const notificationListener = useRef<Subscription>()
   const responseListener = useRef<Subscription>()
   const lastNotificationResponse = Notifications.useLastNotificationResponse()
-  const [initialLoadingComplete, setInitialLoadingComplete] = useState(false)
+  const { initialLoadingComplete, markInitialLoadingComplete } =
+    useInitialLoading()
 
   const api = useMemo(() => apiFactory({ idToken: user.idToken }), [user])
 
@@ -147,11 +149,12 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({ navigation }) => {
       onNotification(opticNotification)
 
       // prevents the cold start callbacks from being called again after this conditional has been triggered
-      setInitialLoadingComplete(true)
+      markInitialLoadingComplete()
     }
   }, [
     initialLoadingComplete,
     lastNotificationResponse,
+    markInitialLoadingComplete,
     onNotification,
     onNotificationResponse,
     secretsLoading,


### PR DESCRIPTION
Adds a conditional to the notification listener useEffect to use the necessary callbacks when a OTP request is pressed whilst the app is closed.

closes: https://github.com/nearform/optic-expo/issues/1155