### PR TITLE
chore: bump husky to version 9

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx --no-install commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx --no-install lint-staged

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:submit:ios": "eas build --platform ios --non-interactive --auto-submit --no-wait",
     "bump:version": "node scripts/bump-version.js",
     "postinstall": "node -e \"fs.copyFileSync('./patch/Linking.js', './node_modules/expo-linking/build/Linking.js')\"",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "dependencies": {
     "@expo-google-fonts/didact-gothic": "^0.2.3",
@@ -104,7 +104,7 @@
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "husky": "^8.0.3",
+    "husky": "^9.0.11",
     "jest": "^28.1.3",
     "jest-expo": "^47.0.1",
     "lint-staged": ">=14",


### PR DESCRIPTION
Updated Husky to latest version. Migration guide found [here](https://github.com/typicode/husky/releases/tag/v9.0.1)