### PR TITLE
Post SDK 52 migration | Step 1: update eas-update ci command

### DIFF
--- a/.github/workflows/expo-eas-update.yml
+++ b/.github/workflows/expo-eas-update.yml
@@ -16,7 +16,6 @@ jobs:
   eas-update:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       pull-requests: write
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/expo-eas-update.yml
+++ b/.github/workflows/expo-eas-update.yml
@@ -16,48 +16,26 @@ jobs:
   eas-update:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
+      
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
+          cache: yarn
+
       - uses: expo/expo-github-action@v8
         with:
           expo-cache: true
           expo-version: latest
           eas-version: latest
           token: ${{ secrets.expo-token }}
-      - run: yarn
-      - uses: actions/github-script@v7
-        id: sanitise-double-quotes
+
+      - run: yarn install
+
+      - name: Create preview
+        uses: expo/expo-github-action/preview@v8
         with:
-          script: return `${{ inputs.message }}`.replaceAll('"',"'")
-          result-encoding: string
-      - name: EAS update
-        id: eas-update
-        run: |
-          EAS_UPDATED_OUTPUT="$(eas update --branch ${{ inputs.channel }} --message '${{ steps.sanitise-double-quotes.outputs.result }}' --non-interactive --json | tr '\n' ' ')"
-          echo "$EAS_UPDATED_OUTPUT"
-          echo "easUpdateOutput=$EAS_UPDATED_OUTPUT" >> $GITHUB_OUTPUT
-      - name: Build comment with preview links
-        if: github.event_name == 'pull_request'
-        id: build-comment
-        uses: actions/github-script@v7
-        with:
-          result-encoding: string
-          script: |
-            const rawEasUpdateOutput = `${{ steps.eas-update.outputs.easUpdateOutput }}`
-            const easUpdateOutput = JSON.parse(rawEasUpdateOutput)
-            const previewLink = `https://expo.dev/accounts/nearform/projects/optic-expo/updates/${easUpdateOutput[0].group}`
-            const qrCodesSections = easUpdateOutput.map(
-              preview =>
-                `${preview.platform}: <br/> <img src='https://qr.expo.dev/eas-update?updateId=${preview.id}&amp;appScheme=exp&amp;host=u.expo.dev' alt='QR Code' />`
-            )
-            return `Preview available at ${previewLink} <br/> <br/> Or scan QR Codes... <br/> <br/> ${qrCodesSections.join('<br/><br/>')}}`
-      - name: Comment preview link
-        if: github.event_name == 'pull_request'
-        uses: expo/expo-github-action/preview-comment@v8
-        with:
-          channel: pr-${{ github.event.number }}
-          message: ${{ steps.build-comment.outputs.result }}
+          command: eas update --branch ${{ inputs.channel }} --message "${{ inputs.message }}"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "expo-camera": "~16.0.13",
     "expo-clipboard": "~7.0.1",
     "expo-constants": "~17.0.4",
-    "expo-dev-client": "~5.0.9",
+    "expo-dev-client": "~5.0.10",
     "expo-device": "~7.0.2",
     "expo-document-picker": "~13.0.2",
     "expo-file-system": "~18.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5821,38 +5821,38 @@ expo-crypto@~14.0.2:
   dependencies:
     base64-js "^1.3.0"
 
-expo-dev-client@~5.0.9:
-  version "5.0.9"
-  resolved "https://registry.yarnpkg.com/expo-dev-client/-/expo-dev-client-5.0.9.tgz#258ceb69d5649e6a1588ccbed5a8bde24aeb2e7a"
-  integrity sha512-8+A5pQFx6A00XXFLpoqkJ1z2QzuLmKsPsnFMktjtl+U+HYhluN8FciaJk4e00pFzeF6YxUdZkS2B3SXjc13JpQ==
+expo-dev-client@~5.0.10:
+  version "5.0.10"
+  resolved "https://registry.yarnpkg.com/expo-dev-client/-/expo-dev-client-5.0.10.tgz#ff77073d3125bec28886360d0878a12508c74665"
+  integrity sha512-iCrpt4XOQjTWbsqlZQSG3wOHsAyboJNg9xpHWBKJy3JFC2uCPH36cX2NvkmEtWqWKXKUjrx0t4B/X9blcDnvSQ==
   dependencies:
-    expo-dev-launcher "5.0.23"
-    expo-dev-menu "6.0.16"
-    expo-dev-menu-interface "1.9.2"
+    expo-dev-launcher "5.0.25"
+    expo-dev-menu "6.0.18"
+    expo-dev-menu-interface "1.9.3"
     expo-manifests "~0.15.5"
     expo-updates-interface "~1.0.0"
 
-expo-dev-launcher@5.0.23:
-  version "5.0.23"
-  resolved "https://registry.yarnpkg.com/expo-dev-launcher/-/expo-dev-launcher-5.0.23.tgz#745c1d758a91737b71b17840d7d871794f0d4f46"
-  integrity sha512-5pZeZgn1zOtmH1UHARHilH6Uy9jV12gz0Pdg/E6neTX24DoohIWtqO/RffDDH/m1hfV61am5tLN+Tt5bf2mUNA==
+expo-dev-launcher@5.0.25:
+  version "5.0.25"
+  resolved "https://registry.yarnpkg.com/expo-dev-launcher/-/expo-dev-launcher-5.0.25.tgz#86f3b6940e652a1724b65a45eb9f844ae1700ec5"
+  integrity sha512-5iH89otFs2lFEXMFRXg5E+YMC1wxoZCp2FuemzLPuNtNC8HX64hUy+PeU8F4H8Xc17K6Hd6zAp9QJqgX4l4eMQ==
   dependencies:
     ajv "8.11.0"
-    expo-dev-menu "6.0.16"
+    expo-dev-menu "6.0.18"
     expo-manifests "~0.15.5"
     resolve-from "^5.0.0"
 
-expo-dev-menu-interface@1.9.2:
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/expo-dev-menu-interface/-/expo-dev-menu-interface-1.9.2.tgz#3515d1365df965f1ad56607cddd133a3c764e23d"
-  integrity sha512-9piGiHZYnNjoO9oQFWlVsndQ1jhTdGCKf81WfCMHbQBamna/zucC1A+jbGpyzE4icXZZ29CpsSd4uVR+tB2Rfw==
+expo-dev-menu-interface@1.9.3:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/expo-dev-menu-interface/-/expo-dev-menu-interface-1.9.3.tgz#5dc618e498b286a50a9272a8bc71969b6db54e23"
+  integrity sha512-KY/dWTBE1l47i9V366JN5rC6YIdOc9hz8yAmZzkl5DrPia5l3M2WIjtnpHC9zUkNjiSiG2urYoOAq4H/uLdmyg==
 
-expo-dev-menu@6.0.16:
-  version "6.0.16"
-  resolved "https://registry.yarnpkg.com/expo-dev-menu/-/expo-dev-menu-6.0.16.tgz#33bbda551a57e373c8e67966c498a1989724013d"
-  integrity sha512-V9+V6dY7sudT0fq5Uq9hnjuTr1qRgu+8ri37TQFBM+ucY2h8x1F7WfJ45pddNXO2zLj4yQRv3q24m7/YueTheQ==
+expo-dev-menu@6.0.18:
+  version "6.0.18"
+  resolved "https://registry.yarnpkg.com/expo-dev-menu/-/expo-dev-menu-6.0.18.tgz#e5540db801d60b095873df52061d0f1bc994bbfa"
+  integrity sha512-QexBMNbZR/J3nNF7UaUs7PcY77bTjLSXWHFTuRM17bGlNCBJWfmoSdKSJ0YQtOTx560bJpCdtWJAn0DR2rj3TA==
   dependencies:
-    expo-dev-menu-interface "1.9.2"
+    expo-dev-menu-interface "1.9.3"
 
 expo-device@~7.0.2:
   version "7.0.2"


### PR DESCRIPTION
Closes item 1 in the post-migration steps

Relates to #1388