### PR TITLE
Post SDK 52 migration | Step 2: disable app stores cd release step

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,16 +13,18 @@ jobs:
     secrets:
       expo-token: ${{ secrets.EXPO_TOKEN }}
 
-  submit-ios:
-    uses: ./.github/workflows/expo-eas-submit.yml
-    with:
-      platform: 'ios'
-    secrets:
-      expo-token: ${{ secrets.EXPO_TOKEN }}
+  # # NOTE: App store submission disabled for now
 
-  submit-android:
-    uses: ./.github/workflows/expo-eas-submit.yml
-    with:
-      platform: 'android'
-    secrets:
-      expo-token: ${{ secrets.EXPO_TOKEN }}
+  # submit-ios:
+  #   uses: ./.github/workflows/expo-eas-submit.yml
+  #   with:
+  #     platform: 'ios'
+  #   secrets:
+  #     expo-token: ${{ secrets.EXPO_TOKEN }}
+
+  # submit-android:
+  #   uses: ./.github/workflows/expo-eas-submit.yml
+  #   with:
+  #     platform: 'android'
+  #   secrets:
+  #     expo-token: ${{ secrets.EXPO_TOKEN }}


### PR DESCRIPTION
Closes item 2 in the post-migration steps

Relates to #1388
